### PR TITLE
Feature/android background audio source

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -11,6 +11,10 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -29,6 +33,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="org.noiseplanet.noisecapture.audio.AudioForegroundService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -35,7 +35,7 @@
         </activity>
 
         <service
-            android:name="org.noiseplanet.noisecapture.audio.AudioForegroundService"
+            android:name="org.noiseplanet.noisecapture.audio.AudioSourceService"
             android:foregroundServiceType="microphone"
             android:exported="false" />
     </application>

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:launchMode="singleTask"
         android:enableOnBackInvokedCallback="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity

--- a/composeApp/src/androidMain/kotlin/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/Platform.android.kt
@@ -13,7 +13,8 @@ class AndroidPlatform : Platform {
             Permission.RECORD_AUDIO,
             Permission.LOCATION_SERVICE_ON,
             Permission.LOCATION_FOREGROUND,
-            Permission.LOCATION_BACKGROUND
+            Permission.LOCATION_BACKGROUND,
+            Permission.POST_NOTIFICATIONS,
         )
 }
 

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -22,9 +22,12 @@ val platformModule: Module = module {
     }
 
     factory<AudioSource> {
-        AndroidAudioSource(logger = get {
-            parametersOf("AudioSource")
-        })
+        AndroidAudioSource(
+            logger = get {
+                parametersOf("AudioSource")
+            },
+            context = get()
+        )
     }
 
     single<Settings> {

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioForegroundService.kt
@@ -1,0 +1,160 @@
+package org.noiseplanet.noisecapture.audio
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.ServiceCompat
+import org.koin.android.ext.android.inject
+import org.koin.core.parameter.parametersOf
+import org.noiseplanet.noisecapture.MainActivity
+import org.noiseplanet.noisecapture.R
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.util.NotificationHelper
+
+/**
+ * An Android service that will keep the audio recording active as long as possible while the
+ * app is not in foreground.
+ *
+ * TODO: Check under which circumstances the system kills the service
+ * TODO: Handle system audio interruptions (playing sound from another app, phone call, timer, ...)
+ * TODO: Handle Android versions prior to Android O
+ */
+internal class AudioForegroundService : Service() {
+
+    // - Constants
+
+    companion object {
+
+        private const val TAG = "AudioForegroundService"
+        private const val FOREGROUND_SERVICE_ID = 1
+    }
+
+
+    // Associated types
+
+    /**
+     * Allows accessing this service from a Context using bindService.
+     */
+    inner class LocalBinder : Binder() {
+
+        /**
+         * Gets this service instance.
+         */
+        fun getService(): AudioForegroundService = this@AudioForegroundService
+    }
+
+
+    // - Properties
+
+    private var audioRecorder: AudioRecorder? = null
+    private var audioThread: Thread? = null
+
+    private val logger: Logger by inject { parametersOf(TAG) }
+    private val binder = LocalBinder()
+
+
+    // - Service
+
+    override fun onBind(intent: Intent?): IBinder {
+        logger.debug("ON BIND")
+        return binder
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        logger.debug("ON START COMMAND")
+
+        // Promote this service to foreground service, showing a notification to the user.
+        // This needs to be called within 10 seconds of starting the service otherwise an
+        // exception will be thrown by the system.
+        startAsForegroundService()
+
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        logger.debug("ON CREATE")
+    }
+
+    override fun onDestroy() {
+        logger.debug("ON DESTROY")
+        stopRecording()
+        super.onDestroy()
+    }
+
+
+    // - Public functions
+
+    /**
+     * Starts recording audio through the provided [AudioRecorder].
+     */
+    fun startRecording(audioRecorder: AudioRecorder) {
+        this.audioRecorder = audioRecorder
+        audioThread = Thread(audioRecorder)
+        audioThread?.start()
+    }
+
+    /**
+     * Stops audio recording and stops this service from running.
+     */
+    fun stopRecording() {
+        audioRecorder?.stopRecording()
+        audioThread?.join()
+        audioRecorder = null
+        stopSelf()
+    }
+
+
+    // - Private functions
+
+    /**
+     * Promotes this service to a foreground service.
+     * This needs to be called within 10 seconds after starting the service otherwise an
+     * exception will be thrown by the system.
+     *
+     * [More details](https://developer.android.com/develop/background-work/services/foreground-services)
+     */
+    private fun startAsForegroundService() {
+        // Create the notification channel
+        NotificationHelper.createAppNotificationChannel(this)
+
+        // Promote this service to foreground service
+        ServiceCompat.startForeground(
+            this,
+            FOREGROUND_SERVICE_ID,
+            buildNotification(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                0
+            }
+        )
+    }
+
+    /**
+     * Builds the notification that will show the service as active to the user.
+     *
+     * TODO: Localize content
+     *
+     * TODO: Notification can still be manually dismissed for Android > 14.
+     *       Does the service get killed then?
+     *
+     * TODO: Add pause/resume controls to the notification?
+     */
+    private fun buildNotification(): Notification {
+        return Notification.Builder(this, NotificationHelper.APP_NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("Notification content title")
+            .setContentText("Notification content text")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentIntent(Intent(this, MainActivity::class.java).let {
+                PendingIntent.getActivity(this, 0, it, PendingIntent.FLAG_IMMUTABLE)
+            })
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
@@ -8,6 +8,7 @@ import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import org.koin.android.ext.android.inject
 import org.koin.core.parameter.parametersOf
@@ -24,7 +25,7 @@ import org.noiseplanet.noisecapture.util.NotificationHelper
  * TODO: Handle system audio interruptions (playing sound from another app, phone call, timer, ...)
  * TODO: Handle Android versions prior to Android O
  */
-internal class AudioForegroundService : Service() {
+internal class AudioSourceService : Service() {
 
     // - Constants
 
@@ -45,7 +46,7 @@ internal class AudioForegroundService : Service() {
         /**
          * Gets this service instance.
          */
-        fun getService(): AudioForegroundService = this@AudioForegroundService
+        fun getService(): AudioSourceService = this@AudioSourceService
     }
 
 
@@ -60,11 +61,16 @@ internal class AudioForegroundService : Service() {
 
     // - Service
 
+    /**
+     * Called when this service is bound to a Context.
+     */
     override fun onBind(intent: Intent?): IBinder {
-        logger.debug("ON BIND")
         return binder
     }
 
+    /**
+     * Called when a Context starts this service.
+     */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         logger.debug("ON START COMMAND")
 
@@ -120,8 +126,10 @@ internal class AudioForegroundService : Service() {
      * [More details](https://developer.android.com/develop/background-work/services/foreground-services)
      */
     private fun startAsForegroundService() {
-        // Create the notification channel
-        NotificationHelper.createAppNotificationChannel(this)
+        // Create the notification channel for newer Android versions
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationHelper.createAppNotificationChannel(this)
+        }
 
         // Promote this service to foreground service
         ServiceCompat.startForeground(
@@ -147,7 +155,7 @@ internal class AudioForegroundService : Service() {
      * TODO: Add pause/resume controls to the notification?
      */
     private fun buildNotification(): Notification {
-        return Notification.Builder(this, NotificationHelper.APP_NOTIFICATION_CHANNEL_ID)
+        return NotificationCompat.Builder(this, NotificationHelper.APP_NOTIFICATION_CHANNEL_ID)
             .setContentTitle("Notification content title")
             .setContentText("Notification content text")
             .setSmallIcon(R.drawable.ic_launcher_foreground)

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
@@ -23,7 +23,6 @@ import org.noiseplanet.noisecapture.util.NotificationHelper
  *
  * TODO: Check under which circumstances the system kills the service
  * TODO: Handle system audio interruptions (playing sound from another app, phone call, timer, ...)
- * TODO: Handle Android versions prior to Android O
  */
 internal class AudioSourceService : Service() {
 
@@ -148,9 +147,6 @@ internal class AudioSourceService : Service() {
      * Builds the notification that will show the service as active to the user.
      *
      * TODO: Localize content
-     *
-     * TODO: Notification can still be manually dismissed for Android > 14.
-     *       Does the service get killed then?
      *
      * TODO: Add pause/resume controls to the notification?
      */

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/PermissionModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/PermissionModule.android.kt
@@ -13,6 +13,7 @@ import org.noiseplanet.noisecapture.permission.delegate.LocationBackgroundPermis
 import org.noiseplanet.noisecapture.permission.delegate.LocationForegroundPermissionDelegate
 import org.noiseplanet.noisecapture.permission.delegate.LocationServicePermissionDelegate
 import org.noiseplanet.noisecapture.permission.delegate.PermissionDelegate
+import org.noiseplanet.noisecapture.permission.delegate.PostNotificationsPermissionDelegate
 
 internal actual fun platformPermissionModule(): Module = module {
     single<PermissionDelegate>(named(Permission.BLUETOOTH_SERVICE_ON.name)) {
@@ -58,7 +59,13 @@ internal actual fun platformPermissionModule(): Module = module {
     single<PermissionDelegate>(named(Permission.RECORD_AUDIO.name)) {
         AudioRecordPermissionDelegate(
             context = get(),
-            activity = inject()
+            activity = inject(),
+        )
+    }
+    single<PermissionDelegate>(named(Permission.POST_NOTIFICATIONS.name)) {
+        PostNotificationsPermissionDelegate(
+            context = get(),
+            activity = inject(),
         )
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/PostNotificationsPermissionDelegate.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/PostNotificationsPermissionDelegate.kt
@@ -11,34 +11,32 @@ import org.noiseplanet.noisecapture.permission.util.checkPermissions
 import org.noiseplanet.noisecapture.permission.util.openAppSettingsPage
 import org.noiseplanet.noisecapture.permission.util.providePermissions
 
-internal class LocationForegroundPermissionDelegate(
+internal class PostNotificationsPermissionDelegate(
     private val context: Context,
     private val activity: Lazy<Activity>,
 ) : PermissionDelegate {
 
     override suspend fun getPermissionState(): PermissionState {
-        return activity.value.checkPermissions(fineLocationPermissions)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return activity.value.checkPermissions(postNotificationPermissions)
+        }
+        return PermissionState.GRANTED
     }
 
     override suspend fun providePermission() {
-        activity.value.providePermissions(fineLocationPermissions) {
-            throw PermissionRequestException(
-                it.localizedMessage ?: "Failed to request foreground location permission"
-            )
+        activity.value.providePermissions(postNotificationPermissions) {
+            throw PermissionRequestException(Permission.POST_NOTIFICATIONS.name)
         }
     }
 
     override fun openSettingPage() {
-        context.openAppSettingsPage(Permission.LOCATION_FOREGROUND)
+        context.openAppSettingsPage(Permission.POST_NOTIFICATIONS)
     }
 }
 
-private val fineLocationPermissions: List<String> =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        listOf(
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-        )
+private val postNotificationPermissions: List<String> =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        listOf(Manifest.permission.POST_NOTIFICATIONS)
     } else {
-        listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        emptyList()
     }

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
@@ -1,0 +1,36 @@
+package org.noiseplanet.noisecapture.util
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+
+internal object NotificationHelper {
+
+    const val APP_NOTIFICATION_CHANNEL_ID = "org.noiseplanet.noisecapture.general"
+
+    private const val APP_NOTIFICATION_CHANNEL_NAME = "General"
+    private const val APP_NOTIFICATION_CHANNEL_DESCRIPTION =
+        "General NoiseCapture notification channel"
+
+    /**
+     * Creates a general channel to post app level notifications
+     *
+     * TODO: Add support for Android < O
+     *
+     * @param context An android context to access [NotificationManager]
+     */
+    fun createAppNotificationChannel(context: Context) {
+        val notificationManager =
+            context.getSystemService(Service.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Create the notification channel
+        val channel = NotificationChannel(
+            APP_NOTIFICATION_CHANNEL_ID,
+            APP_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        channel.description = APP_NOTIFICATION_CHANNEL_DESCRIPTION
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
@@ -4,6 +4,8 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 
 internal object NotificationHelper {
 
@@ -20,6 +22,7 @@ internal object NotificationHelper {
      *
      * @param context An android context to access [NotificationManager]
      */
+    @RequiresApi(Build.VERSION_CODES.O)
     fun createAppNotificationChannel(context: Context) {
         val notificationManager =
             context.getSystemService(Service.NOTIFICATION_SERVICE) as NotificationManager

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/util/NotificationHelper.kt
@@ -18,14 +18,17 @@ internal object NotificationHelper {
     /**
      * Creates a general channel to post app level notifications
      *
-     * TODO: Add support for Android < O
-     *
      * @param context An android context to access [NotificationManager]
      */
     @RequiresApi(Build.VERSION_CODES.O)
     fun createAppNotificationChannel(context: Context) {
         val notificationManager =
             context.getSystemService(Service.NOTIFICATION_SERVICE) as NotificationManager
+
+        // If the channel already exists, don't recreate it again
+        if (notificationManager.getNotificationChannel(APP_NOTIFICATION_CHANNEL_ID) != null) {
+            return
+        }
 
         // Create the notification channel
         val channel = NotificationChannel(

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -109,6 +109,10 @@
     <string name="measurement_windowing_mode_rect_description">Rectangular</string>
 
 
+    <!-- Ongoing measurement notification -->
+    <string name="ongoing_measurement_notification_title">Currently recording audio</string>
+    <string name="ongoing_measurement_notification_body">The NoiseCapture app is currently recording surrounding audio to analyse acoustic parameters. Don't kill the app if you want the recording session to keep going.</string>
+
     <!-- Misc -->
     <string name="na">N/A</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/permission/Permission.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/permission/Permission.kt
@@ -35,4 +35,9 @@ enum class Permission {
      * App audio recording permission.
      */
     RECORD_AUDIO,
+
+    /**
+     * Permission to send notifications.
+     */
+    POST_NOTIFICATIONS,
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
@@ -123,7 +123,7 @@ class DefaultLiveAudioService(
 
     private val _isRunning = MutableStateFlow(false)
     override val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
-    
+
     override val audioSourceState: Flow<AudioSourceState> = audioSource.stateFlow
 
     override fun setupAudioSource(startWhenReady: Boolean) {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
@@ -207,7 +207,6 @@ class DefaultLiveAudioService(
 
         return getAcousticIndicatorsFlow()
             .map { indicators ->
-                logger.debug("indicators: $indicators")
                 if (levelDisplayBands == null) {
                     levelDisplayBands = Array(indicators.nominalFrequencies.size) {
                         LevelDisplayWeightedDecay(SPL_DECAY_RATE, SPL_WINDOW_TIME)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/LiveAudioService.kt
@@ -207,6 +207,7 @@ class DefaultLiveAudioService(
 
         return getAcousticIndicatorsFlow()
             .map { indicators ->
+                logger.debug("indicators: $indicators")
                 if (levelDisplayBands == null) {
                     levelDisplayBands = Array(indicators.nominalFrequencies.size) {
                         LevelDisplayWeightedDecay(SPL_DECAY_RATE, SPL_WINDOW_TIME)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/stateview/PermissionStateViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/stateview/PermissionStateViewModel.kt
@@ -22,9 +22,10 @@ class PermissionStateViewModel(
     private val permissionService: PermissionService,
 ) : ViewModel() {
 
-    val permissionName: String = permission.name
+    private val stateFlow: Flow<PermissionState> =
+        permissionService.getPermissionStateFlow(permission)
 
-    val stateFlow: Flow<PermissionState> = permissionService.getPermissionStateFlow(permission)
+    val permissionName: String = permission.name
 
     val stateIcon: Flow<ImageVector> = stateFlow.map { state ->
         when (state) {


### PR DESCRIPTION
# Description

Bind the audio source to a [Foreground Service](https://developer.android.com/develop/background-work/services/foreground-services?hl=en) to keep it running when the app is in the background.

## Changes

- Added an `AudioSourceService` class for Android that will take care of handling the audio thread as a foreground service
- A persistent notification will be shown in the notification center while the service is running
  - Notifications permission needs to be granted to show notifications for android 13 (tiramisu) and above. The service can still run if the user denies permission, only the notification will not show.
  - For Android 14 (Upside down cake) and above, the persistent notification can still manually be dismissed, it will not stick. However dismissing the notification doesn't stop the service either, it simply removes it from the drawer. [More details](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications)

## Linked issues

#49
#38 

## Remaining TODOs

- This is just a basic implementation of a foreground service, it may need to be tweaked to reduce even more the chances of the service being killed by the system. Further testing on a broader range of devices would be needed for this.
- ATM the service is start as soon as the measurements screen is open and is directly tied to the audio source. Later, we might want to keep both separate to only start the service when a **recording** has been explicitly started by the user. This will be the scope of another PR though as all the elements are not yet present for a more complex implementation.
- We may want to add some controls and additional information to the notification in the future like duration of the measurement, pause/resume/stop buttons, etc.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [x] If needed, new tests have been added
- [x] Extended the README / documentation if necessary
- [x] Added code has been documented
