### PR TITLE
Fix/settings restore value when dismissing keyboard

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/SettingsKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/SettingsKey.kt
@@ -58,9 +58,9 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
         defaultValue = false,
     )
 
-    data object SettingMaxMeasurementDuration : SettingsKey<Int>(
-        Int.serializer(),
-        defaultValue = 30,
+    data object SettingMaxMeasurementDuration : SettingsKey<UInt>(
+        UInt.serializer(),
+        defaultValue = 30u,
     )
 
     data object SettingSpectrogramScaleMode : SettingsKey<SpectrogramScaleMode>(
@@ -74,14 +74,14 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
         defaultValue = 0.0,
     )
 
-    data object SettingCalibrationCountdown : SettingsKey<Int>(
-        Int.serializer(),
-        defaultValue = 4,
+    data object SettingCalibrationCountdown : SettingsKey<UInt>(
+        UInt.serializer(),
+        defaultValue = 4u,
     )
 
-    data object SettingCalibrationDuration : SettingsKey<Int>(
-        Int.serializer(),
-        defaultValue = 6,
+    data object SettingCalibrationDuration : SettingsKey<UInt>(
+        UInt.serializer(),
+        defaultValue = 6u,
     )
 
     data object SettingTestSignalAudioOutput : SettingsKey<CalibrationTestAudioOutput>(
@@ -90,8 +90,8 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
     )
 
     // Map
-    data object SettingMapMaxMeasurementsCount : SettingsKey<Int>(
-        Int.serializer(),
-        defaultValue = 500,
+    data object SettingMapMaxMeasurementsCount : SettingsKey<UInt>(
+        UInt.serializer(),
+        defaultValue = 500u,
     )
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
@@ -2,11 +2,18 @@ package org.noiseplanet.noisecapture.ui.features.settings
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import org.noiseplanet.noisecapture.ui.features.settings.item.SettingsItem
 import org.noiseplanet.noisecapture.ui.theme.listBackground
@@ -16,9 +23,27 @@ import org.noiseplanet.noisecapture.ui.theme.listBackground
 fun SettingsScreen(
     viewModel: SettingsScreenViewModel,
 ) {
+    val focusManager = LocalFocusManager.current
+    val listState = rememberLazyListState()
+    val interactionSource = remember { MutableInteractionSource() }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }
+            .collect {
+                focusManager.clearFocus()
+            }
+    }
+
     LazyColumn(
+        state = listState,
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 32.dp),
         modifier = Modifier.background(listBackground)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+            ) {
+                focusManager.clearFocus()
+            }
     ) {
         viewModel.settingsItems.forEach { (sectionTitle, sectionItems) ->
             stickyHeader {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItem.kt
@@ -77,6 +77,12 @@ fun <T : Any> SettingsItem(
                     SettingsBooleanInput(viewModel as SettingsItemViewModel<Boolean>)
                 }
 
+                // UInt and ULong are not handled as Number types in Kotlin so we need to handle
+                // those in a separate when branch
+                is UInt, ULong -> {
+                    SettingsNumericalInput(viewModel)
+                }
+
                 is Number -> {
                     SettingsNumericalInput(viewModel)
                 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -94,7 +94,7 @@ fun <T : Any> SettingsNumericalInput(
                     .copy(alpha = if (isEnabled) 1.0f else 0.5f)
             ),
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Ascii,
+                keyboardType = KeyboardType.Decimal,
                 imeAction = ImeAction.Done,
             ),
             keyboardActions = KeyboardActions(onDone = {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -105,8 +106,10 @@ fun <T : Any> SettingsNumericalInput(
                 imeAction = ImeAction.Done,
             ),
             keyboardActions = KeyboardActions(onDone = {
-                // Clear focus and dismiss keyboard
-                focusManager.clearFocus()
+                if (getNumericalValue() != null) {
+                    // Clear focus and dismiss keyboard if input is valid
+                    focusManager.clearFocus()
+                }
             }),
             singleLine = true,
             enabled = isEnabled,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -46,14 +46,6 @@ fun <T : Any> SettingsNumericalInput(
     viewModel: SettingsItemViewModel<T>,
     modifier: Modifier = Modifier,
 ) {
-    @Suppress("UNCHECKED_CAST")
-    val defaultValue = when (viewModel.settingKey.defaultValue) {
-        is Int -> 0 as T
-        is Double -> 0.0 as T
-        is Float -> 0.0f as T
-        else -> error("Template parameter must be a numerical value")
-    }
-
     var textFieldValueState by remember {
         val initialValue = viewModel.getValue().toString()
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -70,6 +70,9 @@ fun <T : Any> SettingsNumericalInput(
     fun getNumericalValue(): T? {
         return when (viewModel.settingKey.defaultValue) {
             is Int -> textFieldValueState.text.toIntOrNull() as T?
+            is UInt -> textFieldValueState.text.toUIntOrNull() as T?
+            is Long -> textFieldValueState.text.toLongOrNull() as T?
+            is ULong -> textFieldValueState.text.toULongOrNull() as T?
             is Double -> textFieldValueState.text.toDoubleOrNull() as T?
             is Float -> textFieldValueState.text.toFloatOrNull() as T?
             else -> null

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -116,6 +116,13 @@ fun <T : Any> SettingsNumericalInput(
                 .padding(vertical = 16.dp)
                 .padding(start = 4.dp)
                 .disabledHorizontalPointerInputScroll()
+                .onFocusChanged { focusState ->
+                    if (!focusState.isFocused) {
+                        textFieldValueState = textFieldValueState.copy(
+                            text = viewModel.getValue().toString()
+                        )
+                    }
+                }
         ) {
             TextFieldDefaults.DecorationBox(
                 value = textFieldValueState.text,


### PR DESCRIPTION
# Description

A few adjustments to the way keyboard behaves in settings screen, see below for details

## Changes

- When dismissing the keyboard, restore value back to the currently stored value. That means if an invalid value is entered, when keyboard will dismiss the last entered valid value will be restored in the field
- Keyboard now dismisses when tapping outside of the field or when scrolling
- Now that keyboard can be dismissed without back or done button press, we can use the decimal keyboard again for iOS (previously the regular keyboard was used because iOS decimal keyboard doesn't have a done button)
- For values that should not be negative, use unsigned integers so that entering a negative value in the field triggers a validation error

## Linked issues

#57 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [x] If needed, new tests have been added
- [x] Extended the README / documentation if necessary
- [x] Added code has been documented
