### PR TITLE
Feature/location service

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.preference)
             implementation(libs.koin.android)
+            implementation(libs.google.play.services.android.location)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -36,7 +36,7 @@
         </activity>
 
         <service
-            android:name="org.noiseplanet.noisecapture.audio.AudioSourceService"
+            android:name="org.noiseplanet.noisecapture.services.measurement.ForegroundServiceWrapper"
             android:foregroundServiceType="microphone"
             android:exported="false" />
     </application>

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -11,6 +11,8 @@ import org.noiseplanet.noisecapture.audio.AudioSource
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.services.location.AndroidUserLocationProvider
 import org.noiseplanet.noisecapture.services.location.UserLocationProvider
+import org.noiseplanet.noisecapture.services.measurement.AndroidMeasurementRecordingService
+import org.noiseplanet.noisecapture.services.measurement.MeasurementRecordingService
 
 /**
  * Registers koin components specific to this platform
@@ -23,7 +25,7 @@ val platformModule: Module = module {
     }
 
     factory<AudioSource> {
-        AndroidAudioSource(context = get())
+        AndroidAudioSource()
     }
 
     factory<UserLocationProvider> {
@@ -33,5 +35,15 @@ val platformModule: Module = module {
     single<Settings> {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(get())
         SharedPreferencesSettings(sharedPreferences)
+    }
+
+    /**
+     * Override the default [MeasurementRecordingService] implementation with the one
+     * wrapped into a foreground service.
+     */
+    single<MeasurementRecordingService> {
+        AndroidMeasurementRecordingService(
+            context = get()
+        )
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -5,11 +5,12 @@ import androidx.preference.PreferenceManager
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
 import org.koin.core.module.Module
-import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.noiseplanet.noisecapture.audio.AndroidAudioSource
 import org.noiseplanet.noisecapture.audio.AudioSource
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.services.location.AndroidUserLocationProvider
+import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 
 /**
  * Registers koin components specific to this platform
@@ -22,12 +23,11 @@ val platformModule: Module = module {
     }
 
     factory<AudioSource> {
-        AndroidAudioSource(
-            logger = get {
-                parametersOf("AudioSource")
-            },
-            context = get()
-        )
+        AndroidAudioSource(context = get())
+    }
+
+    factory<UserLocationProvider> {
+        AndroidUserLocationProvider()
     }
 
     single<Settings> {

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AndroidAudioSource.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AndroidAudioSource.kt
@@ -10,19 +10,19 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
+import org.koin.core.component.KoinComponent
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.MicrophoneLocation
+import org.noiseplanet.noisecapture.util.injectLogger
 
 /**
  * Android audio source implementation
  *
- * @param logger [Logger] instance
  * @param context Android [Context] instance
  */
 internal class AndroidAudioSource(
-    private val logger: Logger,
     private val context: Context,
-) : AudioSource {
+) : AudioSource, KoinComponent {
 
     // - Properties
 
@@ -64,6 +64,8 @@ internal class AndroidAudioSource(
             audioSourceService = null
         }
     }
+
+    private val logger: Logger by injectLogger()
 
 
     // - AudioSource

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/audio/AudioSourceService.kt
@@ -18,12 +18,12 @@ import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.ongoing_measurement_notification_body
 import noisecapture.composeapp.generated.resources.ongoing_measurement_notification_title
 import org.jetbrains.compose.resources.getString
-import org.koin.android.ext.android.inject
-import org.koin.core.parameter.parametersOf
+import org.koin.core.component.KoinComponent
 import org.noiseplanet.noisecapture.MainActivity
 import org.noiseplanet.noisecapture.R
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.util.NotificationHelper
+import org.noiseplanet.noisecapture.util.injectLogger
 
 /**
  * An Android service that will keep the audio recording active as long as possible while the
@@ -32,7 +32,7 @@ import org.noiseplanet.noisecapture.util.NotificationHelper
  * TODO: Check under which circumstances the system kills the service
  * TODO: Handle system audio interruptions (playing sound from another app, phone call, timer, ...)
  */
-internal class AudioSourceService : Service() {
+internal class AudioSourceService : Service(), KoinComponent {
 
     // - Constants
 
@@ -66,7 +66,7 @@ internal class AudioSourceService : Service() {
     private var audioRecorder: AudioRecorder? = null
     private var audioThread: Thread? = null
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val logger: Logger by injectLogger()
     private val binder = LocalBinder()
 
 

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/location/AndroidUserLocationProvider.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/location/AndroidUserLocationProvider.kt
@@ -1,0 +1,184 @@
+package org.noiseplanet.noisecapture.services.location
+
+import android.os.Build
+import com.google.android.gms.location.DeviceOrientation
+import com.google.android.gms.location.DeviceOrientationListener
+import com.google.android.gms.location.DeviceOrientationRequest
+import com.google.android.gms.location.LocationListener
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.lastOrNull
+import kotlinx.coroutines.flow.zip
+import kotlinx.coroutines.runBlocking
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.model.Coordinates
+import org.noiseplanet.noisecapture.model.Location
+import org.noiseplanet.noisecapture.model.LocationAccuracy
+import org.noiseplanet.noisecapture.util.injectLogger
+import org.noiseplanet.noisecapture.util.throttleLatest
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+
+private typealias RawLocation = android.location.Location
+
+class AndroidUserLocationProvider :
+    UserLocationProvider,
+    KoinComponent,
+    LocationListener,
+    DeviceOrientationListener {
+
+    // - Constants
+
+    companion object {
+
+        private const val LOCATION_REQUEST_PRIORITY: Int = Priority.PRIORITY_BALANCED_POWER_ACCURACY
+        private const val LOCATION_REQUEST_INTERVAL_SECONDS: Long = 3
+    }
+
+
+    // - Properties
+
+    private val logger: Logger by injectLogger()
+
+    private val rawLocationFlow = MutableSharedFlow<RawLocation>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    private val rawOrientationFlow = MutableSharedFlow<DeviceOrientation>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /**
+     * Specifies the desired accuracy/power policy and interval between location updates
+     */
+    private val locationRequest by lazy {
+        LocationRequest.Builder(
+            LOCATION_REQUEST_PRIORITY,
+            TimeUnit.SECONDS.toMillis(LOCATION_REQUEST_INTERVAL_SECONDS),
+        ).build()
+    }
+    private val locationClient = LocationServices.getFusedLocationProviderClient(get())
+
+    /**
+     * Specifies the desired accuracy/power policy and interval between orientation updates
+     */
+    private val orientationRequest by lazy {
+        DeviceOrientationRequest.Builder(
+            DeviceOrientationRequest.OUTPUT_PERIOD_DEFAULT
+        ).build()
+    }
+    private val orientationClient = LocationServices.getFusedOrientationProviderClient(get())
+
+    /**
+     * Executor on which location and orientation requests will run
+     */
+    private val executor by lazy { Executors.newSingleThreadScheduledExecutor() }
+
+
+    // - UserLocationProvider
+
+    override val liveLocation: Flow<Location>
+        get() = rawOrientationFlow
+            // Device orientation is given every 20ms minimum, so we throttle the values to
+            // match location updates frequency
+            .throttleLatest(TimeUnit.SECONDS.toMillis(LOCATION_REQUEST_INTERVAL_SECONDS))
+            .zip(rawLocationFlow) { orientation, location ->
+                // Zip the results of both flows to get location updates with both
+                // position and orientation.
+                logger.debug("Got new orientation and location: $orientation, $location")
+                buildLocationFromRawData(location, orientation)
+            }
+
+    override val currentLocation: Location?
+        get() = runBlocking { liveLocation.lastOrNull() }
+
+    override fun startUpdatingLocation() {
+        try {
+            // Start both location and orientation updates
+            locationClient.requestLocationUpdates(
+                locationRequest,
+                executor,
+                this,
+            )
+            orientationClient.requestOrientationUpdates(
+                orientationRequest,
+                executor,
+                this,
+            )
+        } catch (exception: SecurityException) {
+            logger.error("The required location permissions were not granted.", exception)
+        }
+    }
+
+    override fun stopUpdatingLocation() {
+        locationClient.removeLocationUpdates(this)
+        orientationClient.removeOrientationUpdates(this)
+    }
+
+
+    // - LocationListener
+
+    override fun onLocationChanged(rawLocation: RawLocation) {
+        rawLocationFlow.tryEmit(rawLocation)
+    }
+
+
+    // - DeviceOrientationListener
+
+    override fun onDeviceOrientationChanged(rawOrientation: DeviceOrientation) {
+        rawOrientationFlow.tryEmit(rawOrientation)
+    }
+
+
+    // - Private functions
+
+    /**
+     * Converts the given raw location and orientation data to a [Location] instance.
+     *
+     * @param rawLocation Raw [android.location.Location] object.
+     * @param rawOrientation Raw [DeviceOrientation] object.
+     */
+    private fun buildLocationFromRawData(
+        rawLocation: RawLocation,
+        rawOrientation: DeviceOrientation,
+    ): Location {
+        val coordinates = Coordinates(
+            lon = rawLocation.longitude,
+            lat = rawLocation.latitude
+        )
+
+        val accuracy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            LocationAccuracy(
+                horizontal = rawLocation.accuracy.toDouble(),
+                orientation = rawOrientation.headingErrorDegrees.toDouble(),
+                // Those parameters are only available since SDK 26 (Android O)
+                speed = rawLocation.speedAccuracyMetersPerSecond.toDouble(),
+                vertical = rawLocation.verticalAccuracyMeters.toDouble(),
+                direction = rawLocation.bearingAccuracyDegrees.toDouble(),
+            )
+        } else {
+            LocationAccuracy(
+                horizontal = rawLocation.accuracy.toDouble(),
+                orientation = rawOrientation.headingDegrees.toDouble(),
+            )
+        }
+
+        return Location(
+            timestamp = rawLocation.time.toDouble(),
+            coordinates = coordinates,
+            altitude = rawLocation.altitude,
+            speed = rawLocation.speed.toDouble(),
+            direction = rawLocation.bearing.toDouble(),
+            orientation = rawOrientation.headingDegrees.toDouble(),
+            accuracy = accuracy,
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/measurement/AndroidMeasurementRecordingService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/measurement/AndroidMeasurementRecordingService.kt
@@ -29,7 +29,6 @@ import org.koin.core.component.get
 import org.noiseplanet.noisecapture.MainActivity
 import org.noiseplanet.noisecapture.R
 import org.noiseplanet.noisecapture.util.NotificationHelper
-import org.noiseplanet.noisecapture.util.injectLogger
 
 
 /**
@@ -167,8 +166,6 @@ internal class ForegroundServiceWrapper : KoinComponent, Service() {
 
     private val job = SupervisorJob()
     private val coroutineScope = CoroutineScope(Dispatchers.IO + job)
-
-    private val logger by injectLogger()
 
     // Build inner service instance using dependency injection
     val innerService = DefaultMeasurementRecordingService(

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/measurement/AndroidMeasurementRecordingService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/measurement/AndroidMeasurementRecordingService.kt
@@ -1,9 +1,12 @@
-package org.noiseplanet.noisecapture.audio
+package org.noiseplanet.noisecapture.services.measurement
 
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.Service
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
@@ -13,41 +16,121 @@ import androidx.core.app.ServiceCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.ongoing_measurement_notification_body
 import noisecapture.composeapp.generated.resources.ongoing_measurement_notification_title
 import org.jetbrains.compose.resources.getString
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 import org.noiseplanet.noisecapture.MainActivity
 import org.noiseplanet.noisecapture.R
-import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.util.NotificationHelper
 import org.noiseplanet.noisecapture.util.injectLogger
 
+
 /**
- * An Android service that will keep the audio recording active as long as possible while the
- * app is not in foreground.
- *
- * TODO: Check under which circumstances the system kills the service
- * TODO: Handle system audio interruptions (playing sound from another app, phone call, timer, ...)
+ * An implementation of [MeasurementRecordingService] that will start a wrapped instance of
+ * [DefaultMeasurementRecordingService] in an Android Foreground Service so it keeps running
+ * when the app is sent to the background (as long as the system doesn't kill it).
  */
-internal class AudioSourceService : Service(), KoinComponent {
+class AndroidMeasurementRecordingService(
+    private val context: Context,
+) : MeasurementRecordingService {
+
+    // - Properties
+
+    /**
+     * Will hold the currently bound wrapper as long as a foreground service is running.
+     */
+    private var wrapper: ForegroundServiceWrapper? = null
+
+    /**
+     * Service connection will allow us to retrieve the wrapper instance when the service is started.
+     */
+    private val serviceConnection = object : ServiceConnection {
+
+        /**
+         * Called when service is connected through [Context.bindService].
+         * Retrieves the wrapper instance from the given [binder] and launches
+         * recording through the wrapped service instance.
+         */
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            checkNotNull(binder) { "Binder is null" }
+
+            val localBinder = binder as ForegroundServiceWrapper.LocalBinder
+            wrapper = localBinder.getService()
+
+            wrapper?.innerService?.start()
+        }
+
+        /**
+         * Called when service is disconnected.
+         */
+        override fun onServiceDisconnected(name: ComponentName?) {
+            wrapper = null
+        }
+    }
+
+    private val _isRecordingFlow = MutableStateFlow(false)
+
+
+    // - MeasurementRecordingService
+
+    override val isRecording: Boolean
+        get() = wrapper?.innerService?.isRecording ?: false
+
+    // TODO: Figure out a way to always listen to the state of the last started service
+    override val isRecordingFlow: StateFlow<Boolean>
+        get() = wrapper?.innerService?.isRecordingFlow ?: _isRecordingFlow
+
+    override fun start() {
+        startForegroundServiceWrapper()
+    }
+
+    override fun endAndSave() {
+        wrapper?.stopForegroundService()
+    }
+
+
+    // - Private functions
+
+    /**
+     * Based on the current OS version, start the [ForegroundServiceWrapper] as a foreground service
+     * with a persistent notification, or as a "regular" service.
+     */
+    private fun startForegroundServiceWrapper() {
+        val intent = Intent(context, ForegroundServiceWrapper::class.java)
+
+        // Based
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent)
+        } else {
+            context.startService(intent)
+        }
+
+        context.bindService(intent, serviceConnection, 0)
+    }
+}
+
+
+/**
+ * Wraps the default implementation of [MeasurementRecordingService] into a Foreground Service.
+ */
+internal class ForegroundServiceWrapper : KoinComponent, Service() {
 
     // - Constants
 
     companion object {
 
-        private const val TAG = "AudioForegroundService"
         private const val FOREGROUND_SERVICE_ID = 1
         private const val NOTIFICATION_REQUEST_CODE = 1029384756
     }
 
-    private val job = SupervisorJob()
-    private val coroutineScope = CoroutineScope(Dispatchers.IO + job)
 
-
-    // Associated types
+    // - Associated types
 
     /**
      * Allows accessing this service from a Context using bindService.
@@ -57,17 +140,25 @@ internal class AudioSourceService : Service(), KoinComponent {
         /**
          * Gets this service instance.
          */
-        fun getService(): AudioSourceService = this@AudioSourceService
+        fun getService(): ForegroundServiceWrapper = this@ForegroundServiceWrapper
     }
 
 
     // - Properties
 
-    private var audioRecorder: AudioRecorder? = null
-    private var audioThread: Thread? = null
-
-    private val logger: Logger by injectLogger()
     private val binder = LocalBinder()
+
+    private val job = SupervisorJob()
+    private val coroutineScope = CoroutineScope(Dispatchers.IO + job)
+
+    private val logger by injectLogger()
+
+    // Build inner service instance using dependency injection
+    val innerService = DefaultMeasurementRecordingService(
+        measurementService = get(),
+        userLocationService = get(),
+        liveAudioService = get(),
+    )
 
 
     // - Service
@@ -83,8 +174,6 @@ internal class AudioSourceService : Service(), KoinComponent {
      * Called when a Context starts this service.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        logger.debug("ON START COMMAND")
-
         // Promote this service to foreground service, showing a notification to the user.
         // This needs to be called within 10 seconds of starting the service otherwise an
         // exception will be thrown by the system.
@@ -93,15 +182,15 @@ internal class AudioSourceService : Service(), KoinComponent {
         return super.onStartCommand(intent, flags, startId)
     }
 
-    override fun onCreate() {
-        super.onCreate()
-        logger.debug("ON CREATE")
-    }
-
+    /**
+     * Called when this service is terminated by the calling context or by the system.
+     */
     override fun onDestroy() {
         super.onDestroy()
-        logger.debug("ON DESTROY")
-        stopRecording()
+
+        if (innerService.isRecording) {
+            innerService.endAndSave()
+        }
         job.cancel()
     }
 
@@ -109,21 +198,10 @@ internal class AudioSourceService : Service(), KoinComponent {
     // - Public functions
 
     /**
-     * Starts recording audio through the provided [AudioRecorder].
+     * Stops the ongoing foreground service, which will trigger [onDestroy], thus
+     * stopping the underlying measurement and saving results before ending this service.
      */
-    fun startRecording(audioRecorder: AudioRecorder) {
-        this.audioRecorder = audioRecorder
-        audioThread = Thread(audioRecorder)
-        audioThread?.start()
-    }
-
-    /**
-     * Stops audio recording and stops this service from running.
-     */
-    fun stopRecording() {
-        audioRecorder?.stopRecording()
-        audioThread?.join()
-        audioRecorder = null
+    fun stopForegroundService() {
         stopSelf()
     }
 
@@ -146,7 +224,7 @@ internal class AudioSourceService : Service(), KoinComponent {
         coroutineScope.launch {
             // Promote this service to foreground service
             ServiceCompat.startForeground(
-                this@AudioSourceService,
+                this@ForegroundServiceWrapper,
                 FOREGROUND_SERVICE_ID,
                 buildNotification(),
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/Koin.kt
@@ -24,10 +24,6 @@ fun initKoin(
 
     return startKoin {
         modules(
-            module {
-                includes(additionalModules)
-            },
-
             servicesModule,
 
             defaultPermissionModule,
@@ -37,6 +33,10 @@ fun initKoin(
             requestPermissionModule,
             measurementModule,
             settingsModule,
+
+            module {
+                includes(additionalModules)
+            },
         )
         createEagerInstances()
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/log/Logger.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/log/Logger.kt
@@ -6,10 +6,7 @@ package org.noiseplanet.noisecapture.log
  * @param tag Tag that will be prefixed before each message logged by this instance.
  *            Should give context information about the caller (e.g. class name).
  */
-abstract class Logger(
-    // TODO: Is there a way to infer class name at build time?
-    protected val tag: String? = null,
-) {
+abstract class Logger(protected val tag: String? = null) {
 
     /**
      * Calls native logger implementation to display the given message from the given log level.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
@@ -1,9 +1,51 @@
 package org.noiseplanet.noisecapture.model
 
 /**
- * A location point with latitude and longitude values
+ * Location data at a given time
+ *
+ * @param timestamp Time at which this point was recorded.
+ * @param coordinates Geographical coordinates of the device.
+ * @param speed The instantaneous speed of the device, measured in meters per second.
+ * @param altitude The altitude above mean sea level associated with a location, measured in meters.
+ * @param direction Direction in which the device is traveling, measured in degrees and relative to due north.
+ * @param orientation Direction in which the device is facing, measured in degrees and relative to true north.
+ *                    May not always be available, hence optional.
+ * @param accuracy Accuracy values associated with each of the measured values. See [LocationAccuracy].
  */
 data class Location(
+    val timestamp: Double,
+    val coordinates: Coordinates,
+    val speed: Double,
+    val altitude: Double,
+    val direction: Double,
+    val orientation: Double?,
+    val accuracy: LocationAccuracy,
+)
+
+
+/**
+ * Accuracy of a location data point.
+ *
+ * @param horizontal The radius of uncertainty for the location, measured in meters.
+ * @param vertical The validity of the altitude values, and their estimated uncertainty, measured in meters.
+ * @param speed The instantaneous speed of the device, measured in meters per second.
+ * @param direction The accuracy of the direction value, measured in degrees.
+ * @param orientation The maximum deviation (measured in degrees) between the reported heading and
+ *                    the true geomagnetic heading. May not always be available, hence optional.
+ */
+data class LocationAccuracy(
+    val horizontal: Double,
+    val speed: Double,
+    val vertical: Double,
+    val direction: Double,
+    val orientation: Double?,
+)
+
+
+/**
+ * A point with latitude and longitude values
+ */
+data class Coordinates(
     val lat: Double,
     val lon: Double,
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
@@ -3,14 +3,14 @@ package org.noiseplanet.noisecapture.model
 /**
  * Location data at a given time
  *
- * @param timestamp Time at which this point was recorded.
- * @param coordinates Geographical coordinates of the device.
- * @param speed The instantaneous speed of the device, measured in meters per second.
- * @param altitude The altitude above mean sea level associated with a location, measured in meters.
- * @param direction Direction in which the device is traveling, measured in degrees and relative to due north.
- * @param orientation Direction in which the device is facing, measured in degrees and relative to true north.
- *                    May not always be available, hence optional.
- * @param accuracy Accuracy values associated with each of the measured values. See [LocationAccuracy].
+ * @param timestamp     Time at which this point was recorded.
+ * @param coordinates   Geographical coordinates of the device.
+ * @param speed         The instantaneous speed of the device, measured in meters per second.
+ * @param altitude      The altitude above mean sea level associated with a location, measured in meters.
+ * @param direction     Direction in which the device is traveling, measured in degrees and relative to due north.
+ * @param orientation   Direction in which the device is facing, measured in degrees and relative to true north.
+ *                      May not always be available, hence optional.
+ * @param accuracy      Accuracy values associated with each of the measured values. See [LocationAccuracy].
  */
 data class Location(
     val timestamp: Double,
@@ -26,19 +26,22 @@ data class Location(
 /**
  * Accuracy of a location data point.
  *
- * @param horizontal The radius of uncertainty for the location, measured in meters.
- * @param vertical The validity of the altitude values, and their estimated uncertainty, measured in meters.
- * @param speed The instantaneous speed of the device, measured in meters per second.
- * @param direction The accuracy of the direction value, measured in degrees.
- * @param orientation The maximum deviation (measured in degrees) between the reported heading and
- *                    the true geomagnetic heading. May not always be available, hence optional.
+ * @param horizontal    The radius of uncertainty for the location, measured in meters.
+ * @param vertical      The validity of the altitude values, and their estimated uncertainty, measured in meters.
+ *                      On Android, only available since SDK 26 (Oreo), hence optional.
+ * @param speed         The instantaneous speed of the device, measured in meters per second.
+ *                      On Android, only available since SDK 26 (Oreo), hence optional.
+ * @param direction     The accuracy of the direction value, measured in degrees.
+ *                      On Android, only available since SDK 26 (Oreo), hence optional.
+ * @param orientation   The maximum deviation (measured in degrees) between the reported heading and
+ *                      the true geomagnetic heading. May not always be available, hence optional.
  */
 data class LocationAccuracy(
     val horizontal: Double,
-    val speed: Double,
-    val vertical: Double,
-    val direction: Double,
-    val orientation: Double?,
+    val speed: Double? = null,
+    val vertical: Double? = null,
+    val direction: Double? = null,
+    val orientation: Double? = null,
 )
 
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/Location.kt
@@ -6,8 +6,11 @@ package org.noiseplanet.noisecapture.model
  * @param timestamp     Time at which this point was recorded.
  * @param coordinates   Geographical coordinates of the device.
  * @param speed         The instantaneous speed of the device, measured in meters per second.
+ *                      Not always available from browser, hence optional.
  * @param altitude      The altitude above mean sea level associated with a location, measured in meters.
+ *                      Not always available from browser, hence optional.
  * @param direction     Direction in which the device is traveling, measured in degrees and relative to due north.
+ *                      Not always available from browser, hence optional.
  * @param orientation   Direction in which the device is facing, measured in degrees and relative to true north.
  *                      May not always be available, hence optional.
  * @param accuracy      Accuracy values associated with each of the measured values. See [LocationAccuracy].
@@ -15,9 +18,9 @@ package org.noiseplanet.noisecapture.model
 data class Location(
     val timestamp: Double,
     val coordinates: Coordinates,
-    val speed: Double,
-    val altitude: Double,
-    val direction: Double,
+    val speed: Double?,
+    val altitude: Double?,
+    val direction: Double?,
     val orientation: Double?,
     val accuracy: LocationAccuracy,
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/liveaudio/DefaultLiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/liveaudio/DefaultLiveAudioService.kt
@@ -15,8 +15,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.audio.AcousticIndicatorsData
 import org.noiseplanet.noisecapture.audio.AcousticIndicatorsProcessing
 import org.noiseplanet.noisecapture.audio.AudioSource
@@ -27,6 +25,7 @@ import org.noiseplanet.noisecapture.audio.signal.LevelDisplayWeightedDecay
 import org.noiseplanet.noisecapture.audio.signal.window.SpectrumData
 import org.noiseplanet.noisecapture.audio.signal.window.SpectrumDataProcessing
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.util.injectLogger
 
 /**
  * Default [LiveAudioService] implementation.
@@ -40,8 +39,6 @@ class DefaultLiveAudioService(
 
     companion object {
 
-        private const val TAG = "LiveAudioService"
-
         const val FFT_SIZE = 4096
         const val FFT_HOP = 2048
 
@@ -52,7 +49,7 @@ class DefaultLiveAudioService(
 
     // - Properties
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val logger: Logger by injectLogger()
 
     private var indicatorsProcessing: AcousticIndicatorsProcessing? = null
     private var spectrumDataProcessing: SpectrumDataProcessing? = null

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/DefaultUserLocationService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/DefaultUserLocationService.kt
@@ -1,15 +1,9 @@
 package org.noiseplanet.noisecapture.services.location
 
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
-import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.Location
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.seconds
 
 
 /**
@@ -17,46 +11,24 @@ import kotlin.time.Duration.Companion.seconds
  */
 class DefaultUserLocationService : UserLocationService, KoinComponent {
 
-    // - Constants
-
-    companion object {
-
-        private const val TAG = "UserLocationService"
-    }
-
-
     // - Properties
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val locationProvider: UserLocationProvider by inject()
 
 
     // - UserLocationService
 
-    override fun getCurrentLocation(): Location? {
-        // TODO: Fetch actual user location
-        logger.debug("Get current location")
+    override val currentLocation: Location?
+        get() = locationProvider.currentLocation
 
-        return Location(
-            lat = Random.nextDouble(),
-            lon = Random.nextDouble()
-        )
+    override val liveLocation: Flow<Location>
+        get() = locationProvider.liveLocation
+
+    override fun startUpdatingLocation() {
+        locationProvider.startUpdatingLocation()
     }
 
-    override fun getLiveLocation(): Flow<Location> {
-        // TODO: Subscribe to live user location
-        logger.debug("Get live location")
-
-        return flow {
-            while (true) {
-                // For now, just emmit dummy locations once every second
-                emit(
-                    Location(
-                        lat = Random.nextDouble(),
-                        lon = Random.nextDouble(),
-                    )
-                )
-                delay(1.seconds.inWholeMilliseconds)
-            }
-        }
+    override fun stopUpdatingLocation() {
+        locationProvider.stopUpdatingLocation()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/UserLocationProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/UserLocationProvider.kt
@@ -4,9 +4,9 @@ import kotlinx.coroutines.flow.Flow
 import org.noiseplanet.noisecapture.model.Location
 
 /**
- * Get user location updates
+ * Common interface for user location provider, each platform should provide its own implementation
  */
-interface UserLocationService {
+interface UserLocationProvider {
 
     /**
      * Gets current user location, if known

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
@@ -9,14 +9,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.audio.AcousticIndicatorsData
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.Location
 import org.noiseplanet.noisecapture.model.Measurement
 import org.noiseplanet.noisecapture.services.liveaudio.LiveAudioService
 import org.noiseplanet.noisecapture.services.location.UserLocationService
+import org.noiseplanet.noisecapture.util.injectLogger
 
 
 class DefaultMeasurementRecordingService(
@@ -25,17 +24,9 @@ class DefaultMeasurementRecordingService(
     private val liveAudioService: LiveAudioService,
 ) : MeasurementRecordingService, KoinComponent {
 
-    // - Constants
-
-    companion object {
-
-        private const val TAG = "RecordingService"
-    }
-
-
     // - Properties
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val logger: Logger by injectLogger()
 
     private val scope = CoroutineScope(Dispatchers.Default)
     private var recordingJob: Job? = null

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
@@ -18,7 +18,7 @@ import org.noiseplanet.noisecapture.services.location.UserLocationService
 import org.noiseplanet.noisecapture.util.injectLogger
 
 
-class DefaultMeasurementRecordingService(
+open class DefaultMeasurementRecordingService(
     private val measurementService: MeasurementService,
     private val userLocationService: UserLocationService,
     private val liveAudioService: LiveAudioService,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
@@ -63,6 +63,8 @@ class DefaultMeasurementRecordingService(
         logger.debug("Start recording")
         _isRecording.tryEmit(true)
 
+        // Start live location updates
+        userLocationService.startUpdatingLocation()
         createMeasurementAndSubscribe()
     }
 
@@ -71,6 +73,9 @@ class DefaultMeasurementRecordingService(
         recordingJob?.cancel()
         recordingJob = null
         _isRecording.tryEmit(false)
+
+        // Stop live location updates
+        userLocationService.stopUpdatingLocation()
 
         measurementService.storeMeasurement(
             Measurement(
@@ -99,7 +104,8 @@ class DefaultMeasurementRecordingService(
         recordingJob = scope.launch {
             coroutineScope {
                 launch {
-                    userLocationService.getLiveLocation().collect { location ->
+                    userLocationService.liveLocation.collect { location ->
+                        logger.debug("New location received: $location")
                         ongoingUserLocationHistory.add(location)
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
@@ -1,27 +1,18 @@
 package org.noiseplanet.noisecapture.services.measurement
 
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.Measurement
+import org.noiseplanet.noisecapture.util.injectLogger
 
 /**
  * Default [MeasurementService] implementation
  */
 class DefaultMeasurementService : MeasurementService, KoinComponent {
 
-    // - Constants
-
-    companion object {
-
-        private const val TAG = "MeasurementService"
-    }
-
-
     // - Properties
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val logger: Logger by injectLogger()
 
 
     // - MeasurementService

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreen.kt
@@ -45,14 +45,14 @@ fun MeasurementScreen(
                 Lifecycle.Event.ON_PAUSE -> {
                     // If there is no ongoing measurement recording, pause audio source
                     if (!viewModel.isRecording) {
-                        viewModel.stopRecordingAudio()
+                        viewModel.stopAudioSource()
                     }
                 }
 
                 Lifecycle.Event.ON_RESUME -> {
                     // If there is no ongoing measurement recording, resume audio source
                     if (!viewModel.isRecording) {
-                        viewModel.startRecordingAudio()
+                        viewModel.startAudioSource()
                     }
                 }
 
@@ -62,6 +62,9 @@ fun MeasurementScreen(
         lifecycleOwner.lifecycle.addObserver(observer)
 
         onDispose {
+            if (viewModel.isRecording) {
+                viewModel.endRecording()
+            }
             viewModel.releaseAudioSource()
             lifecycleOwner.lifecycle.removeObserver(observer)
         }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreen.kt
@@ -79,10 +79,10 @@ fun MeasurementScreen(
                 Row(modifier = Modifier.fillMaxSize()) {
                     Column(modifier = Modifier.fillMaxWidth(.5F)) {
                         AcousticIndicatorsView(viewModel = koinViewModel())
+                        RecordingControls(viewModel = viewModel.recordingControlsViewModel)
                     }
                     Column(modifier = Modifier) {
                         MeasurementPager()
-                        RecordingControls(viewModel = viewModel.recordingControlsViewModel)
                     }
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/MeasurementScreenViewModel.kt
@@ -14,25 +14,16 @@ class MeasurementScreenViewModel(
     private val recordingService: MeasurementRecordingService,
 ) : ViewModel(), ScreenViewModel {
 
-    init {
-        viewModelScope.launch {
-            liveAudioService.audioSourceStateFlow.collect { state ->
-                if (state == AudioSourceState.READY) {
-                    // Start recording audio whenever audio source is done initializing
-                    startRecordingAudio()
-                }
-            }
-        }
-    }
+    // - Properties
 
     val recordingControlsViewModel = RecordingControlsViewModel(
         isPlaying = liveAudioService.isRunningFlow,
         isRecording = recordingService.isRecordingFlow,
         onPlayPauseButtonClick = {
             if (liveAudioService.isRunning) {
-                stopRecordingAudio()
+                stopAudioSource()
             } else {
-                startRecordingAudio()
+                startAudioSource()
             }
         },
         onStartStopButtonClick = {
@@ -51,11 +42,32 @@ class MeasurementScreenViewModel(
     val isRecording: Boolean
         get() = recordingService.isRecording
 
+
+    // - Lifecycle
+
+    init {
+        viewModelScope.launch {
+            liveAudioService.audioSourceStateFlow.collect { state ->
+                if (state == AudioSourceState.READY) {
+                    // Start recording audio whenever audio source is done initializing
+                    startAudioSource()
+                }
+            }
+        }
+    }
+
+
+    // - Public functions
+
     fun setupAudioSource() = liveAudioService.setupAudioSource()
 
-    fun startRecordingAudio() = liveAudioService.startListening()
+    fun startAudioSource() = liveAudioService.startListening()
 
-    fun stopRecordingAudio() = liveAudioService.stopListening()
+    fun stopAudioSource() = liveAudioService.stopListening()
 
     fun releaseAudioSource() = liveAudioService.releaseAudioSource()
+
+    fun startRecording() = recordingService.start()
+
+    fun endRecording() = recordingService.endAndSave()
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/plot/spectrogram/SpectrogramPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/measurement/plot/spectrogram/SpectrogramPlotViewModel.kt
@@ -12,20 +12,17 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.audio.ANDROID_GAIN
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.SpectrogramScaleMode
 import org.noiseplanet.noisecapture.services.liveaudio.LiveAudioService
+import org.noiseplanet.noisecapture.util.injectLogger
 
 class SpectrogramPlotViewModel(
     private val measurementsService: LiveAudioService,
 ) : ViewModel(), KoinComponent {
 
     companion object {
-
-        private const val TAG = "SpectrogramPlotViewModel"
 
         private const val RANGE_DB = 40.0
         private const val MIN_DB = 0.0
@@ -35,7 +32,7 @@ class SpectrogramPlotViewModel(
         const val SPECTROGRAM_STRIP_WIDTH = 32
     }
 
-    private val logger: Logger by inject { parametersOf(TAG) }
+    private val logger: Logger by injectLogger()
 
     private var canvasSize: IntSize = IntSize.Zero
     private val spectrogramBitmaps = mutableStateListOf<SpectrogramBitmap>()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FlowUtil.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FlowUtil.kt
@@ -1,0 +1,22 @@
+package org.noiseplanet.noisecapture.util
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.transform
+
+
+/**
+ * Throttles the values emitted by this flow so that one value is emitted every fixed delay.
+ * Note that if an element is emitted during the delay period, it will still be emitted once the
+ * delay has elapsed and not be dropped. If two elements or more are emitted during the delay period,
+ * only the last element will by emitted once the delay has elapsed.
+ *
+ * @param delayMillis Milliseconds delay between each emitted element.
+ */
+fun <T> Flow<T>.throttleLatest(delayMillis: Long) = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delayMillis)
+    }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/InjectLogger.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/InjectLogger.kt
@@ -1,0 +1,22 @@
+package org.noiseplanet.noisecapture.util
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.parameter.emptyParametersHolder
+import org.koin.core.parameter.parametersOf
+import org.noiseplanet.noisecapture.log.Logger
+
+
+/**
+ * Utility function to inject Logger to koin component by inferring Tag automatically from calling
+ * class name.
+ *
+ * @return Lazy [Logger] injector
+ */
+fun KoinComponent.injectLogger(): Lazy<Logger> {
+    return inject<Logger> {
+        this::class.simpleName?.let {
+            parametersOf(it)
+        } ?: emptyParametersHolder()
+    }
+}

--- a/composeApp/src/iosMain/kotlin/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Platform.ios.kt
@@ -8,12 +8,11 @@ class IOSPlatform : Platform {
         UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 
     override val requiredPermissions: List<Permission>
-        // We can't control laptop settings on the web so we don't
-        // check if location services are on. It will be part of the
-        // location background permission check.
         get() = listOf(
             Permission.RECORD_AUDIO,
-//            Permission.LOCATION_BACKGROUND
+            Permission.LOCATION_FOREGROUND,
+            Permission.LOCATION_SERVICE_ON,
+            Permission.LOCATION_BACKGROUND
         )
 }
 

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -4,11 +4,12 @@ import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
 import org.koin.core.module.Module
-import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.noiseplanet.noisecapture.audio.AudioSource
 import org.noiseplanet.noisecapture.audio.IOSAudioSource
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.services.location.IOSUserLocationProvider
+import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 import platform.Foundation.NSBundle
 
 /**
@@ -23,9 +24,11 @@ val platformModule: Module = module {
     }
 
     factory<AudioSource> {
-        IOSAudioSource(logger = get {
-            parametersOf("AudioSource")
-        })
+        IOSAudioSource()
+    }
+
+    factory<UserLocationProvider> {
+        IOSUserLocationProvider()
     }
 
     single<Settings> {

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/location/IOSUserLocationProvider.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/location/IOSUserLocationProvider.kt
@@ -1,0 +1,172 @@
+package org.noiseplanet.noisecapture.services.location
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.model.Coordinates
+import org.noiseplanet.noisecapture.model.Location
+import org.noiseplanet.noisecapture.model.LocationAccuracy
+import org.noiseplanet.noisecapture.util.injectLogger
+import platform.CoreLocation.CLHeading
+import platform.CoreLocation.CLLocation
+import platform.CoreLocation.CLLocationAccuracy
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLLocationAccuracyBestForNavigation
+import platform.Foundation.NSError
+import platform.Foundation.timeIntervalSince1970
+import platform.darwin.NSObject
+
+/**
+ * IOS implementation of location provider
+ */
+@OptIn(ExperimentalForeignApi::class)
+class IOSUserLocationProvider : UserLocationProvider, KoinComponent {
+
+    // - Constants
+
+    companion object {
+
+        private val DESIRED_ACCURACY: CLLocationAccuracy = kCLLocationAccuracyBestForNavigation
+    }
+
+
+    // - Properties
+
+    private val locationManager by lazy {
+        // Initialize this property lazily so we can create it from the desired thread.
+        CLLocationManager()
+    }
+    private val locationFlow = MutableSharedFlow<Location>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    private val logger: Logger by injectLogger()
+
+    private val delegate = CLLocationProviderDelegate(logger, ::onNewLocationOrHeadingData)
+    private val mainScope = CoroutineScope(Dispatchers.Main)
+
+
+    // - Lifecycle
+
+    init {
+        // CLLocationManager must be initialized on a thread with an active run loop, like the
+        // application main thread. Calls are still asynchronous so it should not mess with the
+        // UI responsiveness.
+        // See: https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate
+        mainScope.launch {
+            // Set desired accuracy and attach delegate to be notified of location updates
+            locationManager.desiredAccuracy = DESIRED_ACCURACY
+            locationManager.delegate = delegate
+        }
+    }
+
+
+    // - UserLocationProvider
+
+    override val currentLocation: Location?
+        get() = locationFlow.replayCache.firstOrNull()
+
+    override val liveLocation: Flow<Location>
+        get() = locationFlow.asSharedFlow()
+
+    override fun startUpdatingLocation() {
+        locationManager.startUpdatingLocation()
+        locationManager.startUpdatingHeading()
+    }
+
+    override fun stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
+        locationManager.stopUpdatingHeading()
+    }
+
+
+    // - Private functions
+
+    /**
+     * Called when either location or heading gets a new recorded value.
+     * If only one value is provided, this method will try to fetch the latest location or heading
+     * value available from the location manager.
+     */
+    private fun onNewLocationOrHeadingData(newLocation: CLLocation?, newHeading: CLHeading?) {
+        // Get the latest available location and heading values
+        val rawLocation: CLLocation = newLocation ?: locationManager.location ?: return
+        val rawHeading: CLHeading? = newHeading ?: locationManager.heading
+
+        // Create Location object from raw values
+        rawLocation.coordinate.useContents {
+            val coordinates = Coordinates(
+                lat = latitude,
+                lon = longitude
+            )
+            val accuracy = LocationAccuracy(
+                horizontal = rawLocation.horizontalAccuracy,
+                vertical = rawLocation.verticalAccuracy,
+                speed = rawLocation.speedAccuracy,
+                direction = rawLocation.courseAccuracy,
+                orientation = rawHeading?.headingAccuracy
+            )
+            // Our timestamp value for this point will be the latest value between heading
+            // and location objects
+            val timestamp = maxOf(
+                a = rawLocation.timestamp.timeIntervalSince1970,
+                b = rawHeading?.timestamp?.timeIntervalSince1970 ?: 0.0,
+            )
+            val location = Location(
+                timestamp = timestamp,
+                coordinates = coordinates,
+                speed = rawLocation.speed,
+                altitude = rawLocation.altitude,
+                direction = rawLocation.course,
+                orientation = rawHeading?.trueHeading,
+                accuracy = accuracy,
+            )
+
+            // Emit new location data through mutable shared flow
+            locationFlow.tryEmit(location)
+        }
+    }
+}
+
+
+/**
+ * [CLLocationManagerDelegateProtocol] implementation to subscribe to location updates
+ */
+private class CLLocationProviderDelegate(
+    private val logger: Logger,
+    private val didReceiveLocationOrHeadingUpdate: (CLLocation?, CLHeading?) -> Unit,
+) : NSObject(), CLLocationManagerDelegateProtocol {
+
+    // - CLLocationManagerDelegateProtocol
+
+    override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
+        if (didUpdateLocations.isEmpty()) {
+            logger.debug("Location history was empty")
+            return
+        }
+
+        val lastLocation = didUpdateLocations.last() as? CLLocation
+        if (lastLocation == null) {
+            logger.warning("Could not properly cast CLLocation object")
+            return
+        }
+
+        didReceiveLocationOrHeadingUpdate(lastLocation, null)
+    }
+
+    override fun locationManager(manager: CLLocationManager, didUpdateHeading: CLHeading) {
+        didReceiveLocationOrHeadingUpdate(null, didUpdateHeading)
+    }
+
+    override fun locationManager(manager: CLLocationManager, didFailWithError: NSError) {
+        logger.warning("Failed to retrieve location: ${didFailWithError.localizedDescription}")
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -10,7 +10,7 @@ class WasmJSPlatform : Platform {
         // location background permission check.
         get() = listOf(
             Permission.RECORD_AUDIO,
-//            Permission.LOCATION_BACKGROUND
+            Permission.LOCATION_BACKGROUND
         )
 }
 

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -3,11 +3,12 @@ package org.noiseplanet.noisecapture
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.StorageSettings
 import org.koin.core.module.Module
-import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.noiseplanet.noisecapture.audio.AudioSource
 import org.noiseplanet.noisecapture.audio.JsAudioSource
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.services.location.UserLocationProvider
+import org.noiseplanet.noisecapture.services.location.WasmJSUserLocationProvider
 
 val platformModule: Module = module {
 
@@ -17,9 +18,11 @@ val platformModule: Module = module {
     }
 
     factory<AudioSource> {
-        JsAudioSource(logger = get {
-            parametersOf("AudioSource")
-        })
+        JsAudioSource()
+    }
+
+    factory<UserLocationProvider> {
+        WasmJSUserLocationProvider()
     }
 
     single<Settings> {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/PermissionModule.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/PermissionModule.wasmjs.kt
@@ -9,13 +9,9 @@ import org.noiseplanet.noisecapture.permission.delegate.PermissionDelegate
 
 internal actual fun platformPermissionModule(): Module = module {
     single<PermissionDelegate>(named(Permission.RECORD_AUDIO.name)) {
-        AudioRecordPermissionDelegate(
-            logger = get()
-        )
+        AudioRecordPermissionDelegate()
     }
     single<PermissionDelegate>(named(Permission.LOCATION_BACKGROUND.name)) {
-        LocationBackgroundPermissionDelegate(
-            logger = get()
-        )
+        LocationBackgroundPermissionDelegate()
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
@@ -1,19 +1,25 @@
 package org.noiseplanet.noisecapture.permission.delegate
 
 import kotlinx.browser.window
+import org.koin.core.component.KoinComponent
 import org.noiseplanet.noisecapture.interop.AudioContext
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.Permission
 import org.noiseplanet.noisecapture.permission.PermissionState
 import org.noiseplanet.noisecapture.permission.util.checkPermission
+import org.noiseplanet.noisecapture.util.injectLogger
 import org.w3c.dom.mediacapture.MediaStreamConstraints
 
 
-class AudioRecordPermissionDelegate(
-    private val logger: Logger,
-) : PermissionDelegate {
+class AudioRecordPermissionDelegate : PermissionDelegate, KoinComponent {
 
+    // - Properties
+
+    private val logger: Logger by injectLogger()
     private var permissionState = PermissionState.NOT_DETERMINED
+
+
+    // - PermissionDelegate
 
     override suspend fun getPermissionState(): PermissionState {
         if (permissionState == PermissionState.GRANTED) {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationBackgroundPermissionDelegate.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationBackgroundPermissionDelegate.kt
@@ -1,17 +1,23 @@
 package org.noiseplanet.noisecapture.permission.delegate
 
+import org.koin.core.component.KoinComponent
 import org.noiseplanet.noisecapture.interop.createGeolocationOptions
 import org.noiseplanet.noisecapture.interop.navigator
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.Permission
 import org.noiseplanet.noisecapture.permission.PermissionState
 import org.noiseplanet.noisecapture.permission.util.checkPermission
+import org.noiseplanet.noisecapture.util.injectLogger
 
-internal class LocationBackgroundPermissionDelegate(
-    private val logger: Logger,
-) : PermissionDelegate {
+internal class LocationBackgroundPermissionDelegate : PermissionDelegate, KoinComponent {
 
+    // - Properties
+
+    private val logger: Logger by injectLogger()
     private var permissionSate = PermissionState.NOT_DETERMINED
+
+
+    // - PermissionDelegate
 
     override suspend fun getPermissionState(): PermissionState {
         if (permissionSate != PermissionState.NOT_DETERMINED) {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/location/WasmJSUserLocationProvider.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/location/WasmJSUserLocationProvider.kt
@@ -1,0 +1,105 @@
+package org.noiseplanet.noisecapture.services.location
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.koin.core.component.KoinComponent
+import org.noiseplanet.noisecapture.interop.GeolocationPosition
+import org.noiseplanet.noisecapture.interop.createGeolocationOptions
+import org.noiseplanet.noisecapture.interop.navigator
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.model.Coordinates
+import org.noiseplanet.noisecapture.model.Location
+import org.noiseplanet.noisecapture.model.LocationAccuracy
+import org.noiseplanet.noisecapture.util.injectLogger
+
+class WasmJSUserLocationProvider : KoinComponent, UserLocationProvider {
+
+    // - Constants
+
+    companion object {
+
+        private const val ENABLE_HIGH_ACCURACY: Boolean = true
+    }
+
+
+    // - Properties
+
+    private val logger: Logger by injectLogger()
+
+    private val locationsFlow = MutableSharedFlow<Location>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /**
+     * Holds the ID returned by `watchPosition`
+     */
+    private var taskId: Int? = null
+
+
+    // - UserLocationProvider
+
+    override val currentLocation: Location?
+        get() = locationsFlow.replayCache.firstOrNull()
+
+    override val liveLocation: Flow<Location>
+        get() = locationsFlow.asSharedFlow()
+
+    override fun startUpdatingLocation() {
+        taskId = navigator?.geolocation?.watchPosition(
+            success = { pos ->
+                pos?.let {
+                    val location = buildLocationFromRawData(it)
+                    locationsFlow.tryEmit(location)
+                }
+            },
+            error = { err ->
+                logger.warning("Unable to retrieve position: ${err.message}")
+            },
+            options = createGeolocationOptions(
+                enableHighAccuracy = ENABLE_HIGH_ACCURACY,
+            )
+        )
+    }
+
+    override fun stopUpdatingLocation() {
+        taskId?.let {
+            navigator?.geolocation?.clearWatch(it)
+        }
+        taskId = null
+    }
+
+
+    // - Private functions
+
+    /**
+     * Parses the raw geolocation data to a [Location] object.
+     *
+     * @param rawLocation Raw geolocation data.
+     *
+     * @return [Location] instance from raw data.
+     */
+    private fun buildLocationFromRawData(rawLocation: GeolocationPosition): Location {
+        val coordinates = Coordinates(
+            lat = rawLocation.coords.latitude,
+            lon = rawLocation.coords.longitude,
+        )
+        val accuracy = LocationAccuracy(
+            horizontal = rawLocation.coords.accuracy,
+            vertical = rawLocation.coords.altitudeAccuracy,
+        )
+        return Location(
+            timestamp = rawLocation.timestamp,
+            coordinates = coordinates,
+            altitude = rawLocation.coords.altitude,
+            speed = rawLocation.coords.speed,
+            // For JS, direction and orientation are represented by the same property
+            // https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates/heading
+            direction = rawLocation.coords.heading,
+            orientation = rawLocation.coords.heading,
+            accuracy = accuracy,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-test-junit = "1.2.1"
 compose-plugin = "1.7.1"
 coroutines = "1.8.0"
 detekt = "1.23.6"
+google-play-services-android-location = "21.2.0"
 junit = "4.13.2"
 koin = "4.0.0"
 kotlin = "2.0.20"
@@ -38,6 +39,7 @@ androidx-material = { group = "com.google.android.material", name = "material", 
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
+google-play-services-android-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "google-play-services-android-location" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -23,13 +23,15 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>TODO: Localize this</string>
+	<string>TODO: Explain bluetooth usage needs</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>TODO: Localize this</string>
+	<string>TODO: Explain foreground and background location usage needs</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>TODO: Explain background location usage needs</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>TODO: Localize this</string>
+	<string>TODO: Explain foreground location usage needs</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>TODO: Localize this</string>
+	<string>TODO: Explain microphone usage needs</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -38,6 +40,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>location</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>


### PR DESCRIPTION
# Description

Adds user location services for all three platforms

## Changes

- Added a `UserLocationProvider` interface with an implementation for each platform to deliver location updates. The location data that can be fetched varies a bit depending on the platform, see `model/Location.kt` for details.
- For Android, previously we used a [Foreground Service]() wrapper for `AudioSource` in order to leave it running when the app is in the background. This PR moves the foreground service wrapping to `MeasurementRecordingService` instead, so that the service is only running when an active recording is ongoing, and not just when microphone audio is monitored. See `AndroidMeasurementRecordingService` for more details.

## Linked issues

#59 

## Remaining TODOs

- The values for location accuracy and frequency are arbitrary for now but we can tweak those later

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [x] If needed, new tests have been added
- [x] Extended the README / documentation if necessary
- [x] Added code has been documented
