### PR TITLE
Feature/user agent

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,7 +1,15 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+
+buildscript {
+    dependencies {
+        classpath(libs.kotlin.gradle.plugin)
+        classpath(libs.buildkonfig.gradle.plugin)
+    }
+}
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -9,6 +17,25 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.buildKonfigGradlePlugin)
+}
+
+class App {
+
+    val packageName: String by project
+    val versionName: String by project
+    val versionCode: String by project
+}
+
+val app = App()
+
+buildkonfig {
+    packageName = app.packageName
+
+    defaultConfigs {
+        buildConfigField(Type.STRING, name = "versionName", value = app.versionName, const = true)
+        buildConfigField(Type.INT, name = "versionCode", value = app.versionCode)
+    }
 }
 
 kotlin {
@@ -94,19 +121,18 @@ kotlin {
 }
 
 android {
-    namespace = "org.noiseplanet.noisecapture"
+    namespace = app.packageName
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         applicationId = "org.noiseplanet.noisecapturekmp"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 2
-        versionName = "0.2.0"
+        versionCode = app.versionCode.toInt()
+        versionName = app.versionName
     }
     packaging {
         resources {

--- a/composeApp/src/androidMain/kotlin/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/Platform.android.kt
@@ -1,9 +1,20 @@
 import android.os.Build
+import org.noiseplanet.noisecapture.BuildKonfig
+import org.noiseplanet.noisecapture.model.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
 
 class AndroidPlatform : Platform {
 
-    override val name: String = "Android ${Build.VERSION.SDK_INT}"
+    override val userAgent: UserAgent
+        get() = UserAgent(
+            versionName = BuildKonfig.versionName,
+            versionCode = BuildKonfig.versionCode,
+            deviceManufacturer = Build.MANUFACTURER,
+            deviceModelName = Build.DEVICE,
+            deviceModelCode = Build.PRODUCT,
+            osName = "Android",
+            osVersion = "${Build.VERSION.SDK_INT} (${Build.VERSION.RELEASE})",
+        )
 
     override val requiredPermissions: List<Permission>
         /**

--- a/composeApp/src/androidMain/kotlin/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/Platform.android.kt
@@ -17,5 +17,3 @@ class AndroidPlatform : Platform {
             Permission.POST_NOTIFICATIONS,
         )
 }
-
-actual fun getPlatform(): Platform = AndroidPlatform()

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -1,6 +1,8 @@
 package org.noiseplanet.noisecapture
 
 import AndroidLogger
+import AndroidPlatform
+import Platform
 import androidx.preference.PreferenceManager
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
@@ -20,6 +22,10 @@ import org.noiseplanet.noisecapture.services.measurement.MeasurementRecordingSer
  * Registers koin components specific to this platform
  */
 val platformModule: Module = module {
+
+    single<Platform> {
+        AndroidPlatform()
+    }
 
     factory<Logger> { params ->
         val tag: String? = params.values.firstOrNull() as? String

--- a/composeApp/src/commonMain/kotlin/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/Platform.kt
@@ -1,3 +1,4 @@
+import org.noiseplanet.noisecapture.model.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
 
 /**
@@ -6,9 +7,10 @@ import org.noiseplanet.noisecapture.permission.Permission
 interface Platform {
 
     /**
-     * Platform name (e.g. iOS, Android, Web, ...)
+     * Information about the device this app is running on,
+     * as well as the app version that is currently running.
      */
-    val name: String
+    val userAgent: UserAgent
 
     /**
      * Permissions required to run the app on this platform.
@@ -22,8 +24,3 @@ interface Platform {
             Permission.LOCATION_SERVICE_ON
         )
 }
-
-/**
- * Gets the [Platform] implementation for the current target.
- */
-expect fun getPlatform(): Platform

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/UserAgent.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/UserAgent.kt
@@ -1,0 +1,47 @@
+package org.noiseplanet.noisecapture.model
+
+import kotlinx.serialization.Serializable
+import org.noiseplanet.noisecapture.BuildKonfig
+
+/**
+ * Information about the currently running app, as well as the device
+ * it is running on.
+ */
+@Serializable
+data class UserAgent(
+
+    /**
+     * App version name (e.g. "1.3.7")
+     */
+    val versionName: String = BuildKonfig.versionName,
+
+    /**
+     * App version number (e.g. 34)
+     */
+    val versionCode: Int = BuildKonfig.versionCode,
+
+    /**
+     * Name of the manufacturer of the device, if available (e.g. "Apple")
+     */
+    val deviceManufacturer: String?,
+
+    /**
+     * Name of the device model, if available (e.g. "Galaxy S24")
+     */
+    val deviceModelName: String?,
+
+    /**
+     * Manufacturer code for the device model, if available (e.g. "Galaxy_S24_AE")
+     */
+    val deviceModelCode: String?,
+
+    /**
+     * Name of operating system, if available (e.g. "macOS")
+     */
+    val osName: String?,
+
+    /**
+     * Operating system version, if available (e.g. "17.8")
+     */
+    val osVersion: String?,
+)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/RequestPermissionScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/RequestPermissionScreenViewModel.kt
@@ -1,11 +1,12 @@
 package org.noiseplanet.noisecapture.ui.features.permission
 
+import Platform
 import androidx.lifecycle.ViewModel
-import getPlatform
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.permission.PermissionState
 import org.noiseplanet.noisecapture.services.permission.PermissionService
@@ -16,9 +17,9 @@ class RequestPermissionScreenViewModel(
     private val permissionService: PermissionService,
 ) : ViewModel(), KoinComponent, ScreenViewModel {
 
-    private val requiredPermissions = getPlatform().requiredPermissions
+    private val platform: Platform by inject()
 
-    val permissionStateViewModels: List<PermissionStateViewModel> = requiredPermissions
+    val permissionStateViewModels: List<PermissionStateViewModel> = platform.requiredPermissions
         .map { permission ->
             get<PermissionStateViewModel> { parametersOf(permission) }
         }
@@ -27,7 +28,7 @@ class RequestPermissionScreenViewModel(
      * Emits true if all required permissions have been granted by the user
      */
     val allPermissionsGranted: Flow<Boolean> = combine(
-        requiredPermissions.map { permission ->
+        platform.requiredPermissions.map { permission ->
             permissionService.getPermissionStateFlow(permission)
         },
         transform = {

--- a/composeApp/src/iosMain/kotlin/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Platform.ios.kt
@@ -15,5 +15,3 @@ class IOSPlatform : Platform {
             Permission.LOCATION_BACKGROUND
         )
 }
-
-actual fun getPlatform(): Platform = IOSPlatform()

--- a/composeApp/src/iosMain/kotlin/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Platform.ios.kt
@@ -1,11 +1,18 @@
+import org.noiseplanet.noisecapture.model.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
 import platform.UIKit.UIDevice
 
 @Suppress("MatchingDeclarationName")
 class IOSPlatform : Platform {
 
-    override val name: String =
-        UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+    override val userAgent: UserAgent
+        get() = UserAgent(
+            deviceManufacturer = "Apple",
+            deviceModelCode = UIDevice.currentDevice.model,
+            deviceModelName = UIDevice.currentDevice.name,
+            osName = UIDevice.currentDevice.systemName,
+            osVersion = UIDevice.currentDevice.systemVersion,
+        )
 
     override val requiredPermissions: List<Permission>
         get() = listOf(

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -1,5 +1,7 @@
 package org.noiseplanet.noisecapture
 
+import IOSPlatform
+import Platform
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
@@ -19,6 +21,10 @@ import platform.Foundation.NSBundle
  */
 @OptIn(ExperimentalSettingsImplementation::class)
 val platformModule: Module = module {
+
+    single<Platform> {
+        IOSPlatform()
+    }
 
     factory<Logger> { params ->
         val tag: String? = params.values.firstOrNull() as? String

--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -1,8 +1,27 @@
+import org.noiseplanet.noisecapture.interop.navigator
+import org.noiseplanet.noisecapture.model.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
 
 class WasmJSPlatform : Platform {
 
-    override val name: String = "Web with Kotlin/Wasm"
+    override val userAgent: UserAgent
+        // Getting device information on web can be tricky due to the variety of
+        // browsers and devices. For now, this is the approach we take:
+        get() = UserAgent(
+            // On some browsers, will return the name of the *browser* manufacturer (e.g. Google Inc.)
+            deviceManufacturer = navigator?.vendor,
+            // Should return the platform running the browser (kind of device name, e.g. MacIntel)
+            deviceModelName = navigator?.platform,
+            // Returns either a fixed version number or a more detailed browser version string.
+            // In most browsers this is included as part of user agent.
+            deviceModelCode = navigator?.appCodeName,
+            // Most device information will be contained here but the format can change from browser
+            // to browser so better include the raw string than trying to parse it.
+            osVersion = navigator?.userAgent,
+            // Using navigator.oscpu only works on Firefox an crashes on other browsers so we
+            // can't rely on that. To filter based on OS, one should rely on [osVersion] instead.
+            osName = "WasmJS",
+        )
 
     override val requiredPermissions: List<Permission>
         // We can't control laptop settings on the web so we don't

--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -13,5 +13,3 @@ class WasmJSPlatform : Platform {
             Permission.LOCATION_BACKGROUND
         )
 }
-
-actual fun getPlatform(): Platform = WasmJSPlatform()

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -1,5 +1,7 @@
 package org.noiseplanet.noisecapture
 
+import Platform
+import WasmJSPlatform
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.StorageSettings
 import org.koin.core.module.Module
@@ -13,6 +15,10 @@ import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 import org.noiseplanet.noisecapture.services.location.WasmJSUserLocationProvider
 
 val platformModule: Module = module {
+
+    single<Platform> {
+        WasmJSPlatform()
+    }
 
     factory<Logger> { params ->
         val tag: String? = params.values.firstOrNull() as? String

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 # Gradle
 org.gradle.jvmargs=-Xmx16048m -Dfile.encoding=UTF-8
-
 # Kotlin
 kotlin.code.style=official
-
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-
 # MPP
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
+# NoiseCapture
+packageName=org.noiseplanet.noisecapture
+versionName=0.2.0
+versionCode=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,12 +9,14 @@ androidx-activity-compose = "1.10.0"
 androidx-viewmodel-compose = "2.8.4"
 androidx-navigation = "2.8.0-alpha11"
 androidx-preference = "1.2.1"
+build-konfig-gradle-plugin = "0.17.0"
 compose-plugin = "1.7.3"
 coroutines = "1.8.0"
 detekt = "1.23.6"
 google-play-services-android-location = "21.3.0"
 koin = "4.0.0"
 kotlin = "2.0.20"
+kotlin-gradle-plugin = "1.9.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.7.3"
 settings-multiplatform = "1.2.0"
@@ -25,11 +27,13 @@ androidx-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecy
 androidx-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-viewmodel-compose" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
+buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "build-konfig-gradle-plugin" }
 google-play-services-android-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "google-play-services-android-location" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-gradle-plugin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
@@ -46,3 +50,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+buildKonfigGradlePlugin = { id = "com.codingfeline.buildkonfig", version.ref = "build-konfig-gradle-plugin" }


### PR DESCRIPTION
# Description

Get information about device and environment the app is running on (app version, device name and brand, os name and version). Will be used when creating measurement objects to store information about the recording environment.

## Changes

- Added a `UserAgent` serializable class that groups all those information.
- Use [BuildKonfig](https://github.com/yshrsmz/BuildKonfig/) third party library to pass down constants to all platforms (currently used to unify version number between platforms but will also come in handy to manage multiple build environment (dev, beta, prod))
- Added platform specific implementations to get device and os information (a bit trickier on web than for iOS and Android because most navigator properties have browser specific implementations, but using `navigator.userAgent` gives most information that we need to know)

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
