### PR TITLE
[WasmJS] Ensure that gain control, echo cancellation and noise suppression are disabled

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/audio/JsAudioSource.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/audio/JsAudioSource.kt
@@ -15,6 +15,7 @@ import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.enums.MicrophoneLocation
 import org.noiseplanet.noisecapture.util.injectLogger
 import org.w3c.dom.mediacapture.MediaStreamConstraints
+import org.w3c.dom.mediacapture.MediaTrackConstraints
 
 
 /**
@@ -70,12 +71,12 @@ internal class JsAudioSource : AudioSource, KoinComponent {
 
         window.navigator.mediaDevices.getUserMedia(
             MediaStreamConstraints(
-                // TODO: Not sure this has any effect...
-                audio = object {
-                    val echoCancellation = false
-                    val autoGainControl = false
-                    val noiseSuppression = false
-                }.toJsReference()
+                audio = MediaTrackConstraints(
+                    advanced = JsArray(),
+                    autoGainControl = false.toJsBoolean(),
+                    noiseSuppression = false.toJsBoolean(),
+                    echoCancellation = false.toJsBoolean(),
+                )
             )
         ).then(onFulfilled = { mediaStream ->
             audioContext = AudioContext()
@@ -110,7 +111,10 @@ internal class JsAudioSource : AudioSource, KoinComponent {
         }, onRejected = { error ->
             logger.error("Error while setting up audio source: $error")
             error
-        })
+        }).catch { error ->
+            logger.error("Error while setting up audio source: $error")
+            error
+        }
     }
 
     override fun start() {


### PR DESCRIPTION
# Description

Fixes the configuration of `MediaTrackConstraints` so that `autoGainControl`, `noiseSuppression` and `echoCancellation` are properly disabled.

## Changes

Using a kotlin object converted to JS using `toJsReference()` doesn't make it a proper JS dictionary. Instead, used the provided `MediaTrackConstraints` interop method to build the correct object.

## Linked issues

#81 

## Remaining TODOs

Tested on Firefox and Chrome, Edge should work the same according the [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints).
Safari is not supported by Compose atm.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
