### PR TITLE
Feature/show error unsupported browser

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -3,10 +3,99 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>KotlinProject</title>
-    <link type="text/css" rel="stylesheet" href="styles.css">
+    <title>NoiseCapture</title>
     <script type="application/javascript" src="composeApp.js"></script>
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: white;
+            overflow: hidden;
+        }
+
+        #warning {
+            position: absolute;
+            top: 100px;
+            left: 100px;
+            max-width: 830px;
+            z-index: 100;
+            background-color: white;
+            font-size: initial;
+            display: none;
+        }
+        #warning li {
+            padding-bottom: 15px;
+        }
+
+        #warning span.code {
+            font-family: monospace;
+        }
+
+        ul {
+            margin-top: 0;
+            margin-bottom: 15px;
+        }
+
+        #footer {
+            position: fixed;
+            bottom: 0;
+            width: 100%;
+            z-index: 1000;
+            background-color: white;
+            font-size: initial;
+        }
+
+        #close {
+            position: absolute;
+            top: 0;
+            right: 10px;
+            cursor: pointer;
+        }
+    </style>
 </head>
 <body>
+<!--<canvas id="ComposeTarget"></canvas>-->
+
+<div id="warning">
+    ⚠️ Sorry, it appears that your browser is currently not supported by this version of
+    NoiseCapture.
+    <br/>
+    For more information, see <a href="https://kotl.in/wasm-help">https://kotl.in/wasm-help</a>.
+    <br/>
+    <br/>
+    <ul>
+        <li>For <b>Chrome</b> and <b>Chromium-based</b> browsers (Edge, Brave etc.), it <b>should
+            just work</b> since version 119.
+        </li>
+        <li>For <b>Firefox</b> 120 it <b>should just work</b>.</li>
+        <li>For <b>Firefox</b> 119:
+            <ol>
+                <li>Open <span class="code">about:config</span> in the browser.</li>
+                <li>Enable <strong>javascript.options.wasm_gc</strong>.</li>
+                <li>Refresh this page.</li>
+            </ol>
+        </li>
+    </ul>
+    If you think this is a mistake, or want to follow further developments, check the issue board on
+    our <a href="https://github.com/Universite-Gustave-Eiffel/NoiseCaptureClient/issues">Github
+    repository!</a>
+</div>
 </body>
+
+<script type="application/javascript">
+    const unhandledError = (event, error) => {
+        if (error instanceof WebAssembly.CompileError) {
+            document.getElementById("warning").style.display="initial";
+
+            // Hide a Scary Webpack Overlay which is less informative in this case.
+            const webpackOverlay = document.getElementById("webpack-dev-server-client-overlay");
+            if (webpackOverlay != null) webpackOverlay.style.display="none";
+        }
+    }
+    addEventListener("error", (event) => unhandledError(event, event.error));
+    addEventListener("unhandledrejection", (event) => unhandledError(event, event.reason));
+</script>
+
 </html>

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -3,61 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title>NoiseCapture</title>
     <script type="application/javascript" src="composeApp.js"></script>
-    <style>
-        html, body {
-            width: 100%;
-            height: 100%;
-            margin: 0;
-            padding: 0;
-            background-color: white;
-            overflow: hidden;
-        }
-
-        #warning {
-            position: absolute;
-            top: 100px;
-            left: 100px;
-            max-width: 830px;
-            z-index: 100;
-            background-color: white;
-            font-size: initial;
-            display: none;
-        }
-        #warning li {
-            padding-bottom: 15px;
-        }
-
-        #warning span.code {
-            font-family: monospace;
-        }
-
-        ul {
-            margin-top: 0;
-            margin-bottom: 15px;
-        }
-
-        #footer {
-            position: fixed;
-            bottom: 0;
-            width: 100%;
-            z-index: 1000;
-            background-color: white;
-            font-size: initial;
-        }
-
-        #close {
-            position: absolute;
-            top: 0;
-            right: 10px;
-            cursor: pointer;
-        }
-    </style>
 </head>
-<body>
-<!--<canvas id="ComposeTarget"></canvas>-->
 
+<body>
 <div id="warning">
     ⚠️ Sorry, it appears that your browser is currently not supported by this version of
     NoiseCapture.

--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -3,5 +3,43 @@ html, body {
     height: 100%;
     margin: 0;
     padding: 0;
+    background-color: #FEF7FF;
     overflow: hidden;
+}
+
+#warning {
+    position: absolute;
+    top: 100px;
+    left: 100px;
+    max-width: 830px;
+    z-index: 100;
+    font-size: initial;
+    display: none;
+}
+#warning li {
+    padding-bottom: 15px;
+}
+
+#warning span.code {
+    font-family: monospace;
+}
+
+ul {
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+#footer {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    z-index: 1000;
+    font-size: initial;
+}
+
+#close {
+    position: absolute;
+    top: 0;
+    right: 10px;
+    cursor: pointer;
 }


### PR DESCRIPTION
# Description

If browser is not supported (Safari for instance), show a user friendly error instead of ugly Webpack compile error.

## Changes

Based on [this KMP example](https://github.com/JetBrains/compose-multiplatform/blob/master/examples/imageviewer/webApp/src/wasmJsMain/resources/index.html) from JetBrains, catch the compile error in a script in `index.html` and show an alternative error message listing supported browsers.

Note: The 1.8.0 version of the compose multiplatform plugin says it should now support Safari but it is still in Beta atm so I'd rather wait for a stable release before updating.

## Linked issues

- #80

## Remaining TODOs

Error message could be improved and perhaps localised but for now it will do the job.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
