### PR TITLE
Clip acousitc idicator values to -999 to avoid -Inf when serializing to JSON

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
@@ -78,7 +78,7 @@ class AcousticIndicatorsProcessing(val sampleRate: Int, val dbGain: Double = AND
                         samples.epoch,
                         max(leq, -999.0),   // Clip values to -999dB to avoid -Inf in JSON exports
                         max(laeq, -999.0),  // Clip values to -999dB to avoid -Inf in JSON exports
-                        max(rms, -999.0),   // Clip values to -999dB to avoid -Inf in JSON exports
+                        rms,
                         leqsPerThirdOctave,
                     )
                 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
@@ -4,6 +4,7 @@ import org.noiseplanet.noisecapture.audio.signal.SpectrumChannel
 import org.noiseplanet.noisecapture.audio.signal.get44100HZ
 import org.noiseplanet.noisecapture.audio.signal.get48000HZ
 import kotlin.math.log10
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -68,14 +69,16 @@ class AcousticIndicatorsProcessing(val sampleRate: Int, val dbGain: Double = AND
                 val thirdOctave = spectrumChannel.processSamples(windowData)
                 val thirdOctaveGain = 10 * log10(10.0.pow(dbGain / 10.0) / thirdOctave.size)
                 val leqsPerThirdOctave = nominalFrequencies
-                    .zip(thirdOctave.map { it + thirdOctaveGain })
-                    .toMap()
+                    .zip(thirdOctave.map {
+                        // Clip values to -999dB to avoid -Inf in JSON exports
+                        max(it + thirdOctaveGain, -999.0)
+                    }).toMap()
                 acousticIndicatorsDataList.add(
                     AcousticIndicatorsData(
                         samples.epoch,
-                        leq,
-                        laeq,
-                        rms,
+                        max(leq, -999.0),   // Clip values to -999dB to avoid -Inf in JSON exports
+                        max(laeq, -999.0),  // Clip values to -999dB to avoid -Inf in JSON exports
+                        max(rms, -999.0),   // Clip values to -999dB to avoid -Inf in JSON exports
                         leqsPerThirdOctave,
                     )
                 )


### PR DESCRIPTION
# Description

Fixes a bug where acoustic indicator values could be `-Infinity` so JSON serialisation would fail.

## Changes

When building `AcousticIndicators` object, clip values to -999.0dB.

## Linked issues

#83 

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
