### PR TITLE
Feature/min max avg

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
@@ -3,6 +3,7 @@ package org.noiseplanet.noisecapture.audio
 import org.noiseplanet.noisecapture.audio.signal.SpectrumChannel
 import org.noiseplanet.noisecapture.audio.signal.get44100HZ
 import org.noiseplanet.noisecapture.audio.signal.get48000HZ
+import org.noiseplanet.noisecapture.util.roundTo
 import kotlin.math.log10
 import kotlin.math.max
 import kotlin.math.min
@@ -71,14 +72,16 @@ class AcousticIndicatorsProcessing(val sampleRate: Int, val dbGain: Double = AND
                 val leqsPerThirdOctave = nominalFrequencies
                     .zip(thirdOctave.map {
                         // Clip values to -999dB to avoid -Inf in JSON exports
-                        max(it + thirdOctaveGain, -999.0)
+                        max(it + thirdOctaveGain, -999.0).roundTo(1)
                     }).toMap()
                 acousticIndicatorsDataList.add(
+                    // TODO: Adapt this to directly return LeqRecords
                     AcousticIndicatorsData(
                         samples.epoch,
-                        max(leq, -999.0),   // Clip values to -999dB to avoid -Inf in JSON exports
-                        max(laeq, -999.0),  // Clip values to -999dB to avoid -Inf in JSON exports
-                        rms,
+                        // Clip values to -999dB to avoid -Inf in JSON exports
+                        max(leq, -999.0).roundTo(1),
+                        max(laeq, -999.0).roundTo(1),
+                        rms.roundTo(1),
                         leqsPerThirdOctave,
                     )
                 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LAeqMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LAeqMetrics.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @param recordsCount Number of records taken into account.
  */
 @Serializable
-data class LeqMetrics(
+data class LAeqMetrics(
     val min: Double,
     val average: Double,
     val max: Double,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LeqMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LeqMetrics.kt
@@ -1,0 +1,20 @@
+package org.noiseplanet.noisecapture.model.dao
+
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Overall Leq metrics of a measurement.
+ *
+ * @param min Min Leq value over the total duration of the measurement.
+ * @param average Average Leq value over the total duration of the measurement.
+ * @param max Max Leq value over the total duration of the measurement.
+ * @param recordsCount Number of records taken into account.
+ */
+@Serializable
+data class LeqMetrics(
+    val min: Double,
+    val average: Double,
+    val max: Double,
+    val recordsCount: Long,
+)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
@@ -26,6 +26,7 @@ data class Measurement(
 
     val locationSequenceIds: List<String> = emptyList(),
     val leqsSequenceIds: List<String> = emptyList(),
+    val leqMetrics: LeqMetrics,
 
     val recordedAudioUrl: String? = null,
 )
@@ -50,6 +51,7 @@ data class MutableMeasurement(
 
     val locationSequenceIds: MutableList<String> = mutableListOf(),
     val leqsSequenceIds: MutableList<String> = mutableListOf(),
+    var leqMetrics: LeqMetrics? = null,
 
     var recordedAudioUrl: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
@@ -26,7 +26,7 @@ data class Measurement(
 
     val locationSequenceIds: List<String> = emptyList(),
     val leqsSequenceIds: List<String> = emptyList(),
-    val leqMetrics: LeqMetrics,
+    val laeqMetrics: LAeqMetrics,
 
     val recordedAudioUrl: String? = null,
 )
@@ -51,7 +51,7 @@ data class MutableMeasurement(
 
     val locationSequenceIds: MutableList<String> = mutableListOf(),
     val leqsSequenceIds: MutableList<String> = mutableListOf(),
-    var leqMetrics: LeqMetrics? = null,
+    var laeqMetrics: LAeqMetrics? = null,
 
     var recordedAudioUrl: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
@@ -168,7 +168,7 @@ open class DefaultMeasurementRecordingService : MeasurementRecordingService, Koi
                         val leqRecord = LeqRecord(
                             // TODO: Properly fill LZeq and LCeq
                             timestamp = Clock.System.now().toEpochMilliseconds(),
-                            lzeq = indicators.laeq,
+                            lzeq = indicators.leq,
                             laeq = indicators.laeq,
                             lceq = indicators.laeq,
                             leqsPerThirdOctave = indicators.leqsPerThirdOctave

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
@@ -1,10 +1,13 @@
 package org.noiseplanet.noisecapture.services.measurement
 
 import Platform
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.model.dao.LeqMetrics
 import org.noiseplanet.noisecapture.model.dao.LeqRecord
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationRecord
@@ -14,7 +17,10 @@ import org.noiseplanet.noisecapture.model.dao.MutableMeasurement
 import org.noiseplanet.noisecapture.services.storage.StorageService
 import org.noiseplanet.noisecapture.services.storage.injectStorageService
 import org.noiseplanet.noisecapture.util.injectLogger
+import org.noiseplanet.noisecapture.util.roundTo
 import kotlin.concurrent.Volatile
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -36,6 +42,8 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
 
 
     // - Properties
+
+    private val leqMetricsFlow: MutableStateFlow<LeqMetrics?> = MutableStateFlow(null)
 
     private val logger: Logger by injectLogger()
     private val platform: Platform by inject()
@@ -106,6 +114,24 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
             )
             currentLeqSequenceFragment?.push(record)
         }
+        // Update (or initialize) ongoing measurement's leq metrics
+        val leqMetrics = ongoingMeasurement.leqMetrics?.let { currentMetrics ->
+            val average = currentMetrics.average +
+                (record.lzeq - currentMetrics.average) / currentMetrics.recordsCount
+            LeqMetrics(
+                min = min(record.lzeq, currentMetrics.min),
+                average = average.roundTo(1),
+                max = max(record.lzeq, currentMetrics.max),
+                recordsCount = currentMetrics.recordsCount + 1
+            )
+        } ?: LeqMetrics(
+            min = record.lzeq,
+            average = record.lzeq,
+            max = record.lzeq,
+            recordsCount = 1,
+        )
+        ongoingMeasurement.leqMetrics = leqMetrics
+        leqMetricsFlow.emit(leqMetrics)
         // Check if sequence fragment has reached its limit.
         // Since location updates come at an irregular rate, we rely on leq records to determine
         // when fragments should stop.
@@ -140,6 +166,10 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
         onSequenceFragmentEnd()
     }
 
+    override fun getOngoingMeasurementLeqMetricsFlow(): Flow<LeqMetrics?> {
+        return leqMetricsFlow
+    }
+
 
     // - Private functions
 
@@ -169,6 +199,7 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
      */
     private suspend fun saveOngoingMeasurement() {
         val ongoingMeasurement = ongoingMeasurement ?: return
+        val leqMetrics = ongoingMeasurement.leqMetrics ?: return
         val now = Clock.System.now().toEpochMilliseconds()
 
         logger.info("Storing measurement with id ${ongoingMeasurement.uuid}")
@@ -182,8 +213,10 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
             userAgent = platform.userAgent,
             locationSequenceIds = ongoingMeasurement.locationSequenceIds,
             leqsSequenceIds = ongoingMeasurement.leqsSequenceIds,
-            recordedAudioUrl = ongoingMeasurement.recordedAudioUrl
+            recordedAudioUrl = ongoingMeasurement.recordedAudioUrl,
+            leqMetrics = leqMetrics,
         )
         measurementStorageService.set(measurement.uuid, measurement)
+        leqMetricsFlow.emit(null)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/MeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/MeasurementService.kt
@@ -1,7 +1,7 @@
 package org.noiseplanet.noisecapture.services.measurement
 
 import kotlinx.coroutines.flow.Flow
-import org.noiseplanet.noisecapture.model.dao.LeqMetrics
+import org.noiseplanet.noisecapture.model.dao.LAeqMetrics
 import org.noiseplanet.noisecapture.model.dao.LeqRecord
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationRecord
@@ -105,5 +105,5 @@ interface MeasurementService {
      *
      * @return Ongoing measurement leq metrics updated in real time.
      */
-    fun getOngoingMeasurementLeqMetricsFlow(): Flow<LeqMetrics?>
+    fun getOngoingMeasurementLaeqMetricsFlow(): Flow<LAeqMetrics?>
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/MeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/MeasurementService.kt
@@ -1,5 +1,7 @@
 package org.noiseplanet.noisecapture.services.measurement
 
+import kotlinx.coroutines.flow.Flow
+import org.noiseplanet.noisecapture.model.dao.LeqMetrics
 import org.noiseplanet.noisecapture.model.dao.LeqRecord
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationRecord
@@ -96,4 +98,12 @@ interface MeasurementService {
      * Closes the ongoing measurement, saving every remaining data to local storage.
      */
     suspend fun closeOngoingMeasurement()
+
+    /**
+     * Gets a flow of leq metrics (min/max/average) for the ongoing measurement, or
+     * null if no measurement is currently running.
+     *
+     * @return Ongoing measurement leq metrics updated in real time.
+     */
+    fun getOngoingMeasurementLeqMetricsFlow(): Flow<LeqMetrics?>
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -22,9 +22,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
 import org.noiseplanet.noisecapture.ui.components.button.NCButton
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MAX
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MIN
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
+import org.noiseplanet.noisecapture.util.isInVuMeterRange
 import org.noiseplanet.noisecapture.util.roundTo
 
 
@@ -35,6 +34,7 @@ fun SoundLevelMeterView(
     // - Properties
 
     val currentSoundPressureLevel by viewModel.soundPressureLevelFlow.collectAsState(0.0)
+    val roundedSpl = currentSoundPressureLevel.roundTo(1)
     val currentLeqMetrics by viewModel.laeqMetricsFlow.collectAsState(null)
 
 
@@ -58,11 +58,8 @@ fun SoundLevelMeterView(
                         ),
                     )
 
-                    val isSplInRange = currentSoundPressureLevel in VU_METER_DB_MIN..VU_METER_DB_MAX
-                    val roundedSpl = currentSoundPressureLevel.roundTo(1)
-
                     Text(
-                        text = if (isSplInRange) roundedSpl.toString() else "-",
+                        text = if (roundedSpl.isInVuMeterRange()) roundedSpl.toString() else "-",
                         style = MaterialTheme.typography.headlineLarge.copy(
                             fontWeight = FontWeight.Black,
                             fontSize = 36.sp,
@@ -99,7 +96,7 @@ fun SoundLevelMeterView(
                                 )
                                 val value = metric.value
                                 Text(
-                                    text = if (value != null && value in VU_METER_DB_MIN..VU_METER_DB_MAX) {
+                                    text = if (value != null && value.isInVuMeterRange()) {
                                         value.toString()
                                     } else "-",
                                     style = MaterialTheme.typography.bodyMedium.copy(
@@ -126,8 +123,6 @@ fun SoundLevelMeterView(
 
             VuMeter(
                 ticks = viewModel.vuMeterTicks,
-                minimum = VU_METER_DB_MIN,
-                maximum = VU_METER_DB_MAX,
                 value = currentSoundPressureLevel,
             )
         }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -25,7 +25,7 @@ import org.noiseplanet.noisecapture.ui.components.button.NCButton
 import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MAX
 import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MIN
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
-import kotlin.math.round
+import org.noiseplanet.noisecapture.util.roundTo
 
 
 @Composable
@@ -35,6 +35,7 @@ fun SoundLevelMeterView(
     // - Properties
 
     val currentSoundPressureLevel by viewModel.soundPressureLevelFlow.collectAsState(0.0)
+    val currentLeqMetrics by viewModel.leqMetricsFlow.collectAsState(null)
 
 
     // - Layout
@@ -58,7 +59,7 @@ fun SoundLevelMeterView(
                     )
 
                     val isSplInRange = currentSoundPressureLevel in VU_METER_DB_MIN..VU_METER_DB_MAX
-                    val roundedSpl = round(currentSoundPressureLevel * 10.0) / 10.0
+                    val roundedSpl = currentSoundPressureLevel.roundTo(1)
 
                     Text(
                         text = if (isSplInRange) roundedSpl.toString() else "-",
@@ -77,15 +78,15 @@ fun SoundLevelMeterView(
                         listOf(
                             MeasurementStatistics(
                                 label = stringResource(viewModel.minDbALabel),
-                                value = "-",
+                                value = currentLeqMetrics?.min?.toString() ?: "-",
                             ),
                             MeasurementStatistics(
                                 label = stringResource(viewModel.avgDbALabel),
-                                value = "-",
+                                value = currentLeqMetrics?.average?.toString() ?: "-",
                             ),
                             MeasurementStatistics(
                                 label = stringResource(viewModel.maxDbALabel),
-                                value = "-",
+                                value = currentLeqMetrics?.max?.toString() ?: "-",
                             ),
                         ).forEach {
                             Column(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -47,7 +47,7 @@ fun SoundLevelMeterView(
         ) {
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
                 modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth()
             ) {
                 Column(horizontalAlignment = Alignment.Start) {
@@ -76,33 +76,39 @@ fun SoundLevelMeterView(
                         Modifier.align(Alignment.Top),
                     ) {
                         listOf(
-                            MeasurementStatistics(
+                            LeqMetricViewModel(
                                 label = stringResource(viewModel.minDbALabel),
-                                value = currentLeqMetrics?.min?.toString() ?: "-",
+                                value = currentLeqMetrics?.min,
                             ),
-                            MeasurementStatistics(
+                            LeqMetricViewModel(
                                 label = stringResource(viewModel.avgDbALabel),
-                                value = currentLeqMetrics?.average?.toString() ?: "-",
+                                value = currentLeqMetrics?.average,
                             ),
-                            MeasurementStatistics(
+                            LeqMetricViewModel(
                                 label = stringResource(viewModel.maxDbALabel),
-                                value = currentLeqMetrics?.max?.toString() ?: "-",
+                                value = currentLeqMetrics?.max,
                             ),
-                        ).forEach {
+                        ).forEach { metric ->
                             Column(
                                 horizontalAlignment = Alignment.Start,
-                                modifier = Modifier.width(50.dp),
+                                modifier = Modifier.width(56.dp),
                             ) {
                                 Text(
-                                    text = it.label,
+                                    text = metric.label,
                                     style = MaterialTheme.typography.labelLarge
                                 )
+                                val value = metric.value
                                 Text(
-                                    text = it.value,
-                                    style = MaterialTheme.typography.headlineLarge.copy(
+                                    text = if (value != null && value in VU_METER_DB_MIN..VU_METER_DB_MAX) {
+                                        value.toString()
+                                    } else "-",
+                                    style = MaterialTheme.typography.bodyMedium.copy(
                                         fontWeight = FontWeight.Bold,
                                         fontSize = 20.sp,
-                                        textAlign = TextAlign.Start
+                                        textAlign = TextAlign.Start,
+                                        color = metric.value?.let {
+                                            NoiseLevelColorRamp.getColorForSPLValue(it)
+                                        } ?: MaterialTheme.colorScheme.onSurface,
                                     )
                                 )
                             }
@@ -129,7 +135,7 @@ fun SoundLevelMeterView(
 }
 
 
-private data class MeasurementStatistics(
+private data class LeqMetricViewModel(
     val label: String,
-    val value: String,
+    val value: Double?,
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -35,7 +35,7 @@ fun SoundLevelMeterView(
     // - Properties
 
     val currentSoundPressureLevel by viewModel.soundPressureLevelFlow.collectAsState(0.0)
-    val currentLeqMetrics by viewModel.leqMetricsFlow.collectAsState(null)
+    val currentLeqMetrics by viewModel.laeqMetricsFlow.collectAsState(null)
 
 
     // - Layout

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
@@ -22,6 +22,7 @@ import org.noiseplanet.noisecapture.services.audio.LiveAudioService
 import org.noiseplanet.noisecapture.services.measurement.MeasurementService
 import org.noiseplanet.noisecapture.ui.components.button.ButtonStyle
 import org.noiseplanet.noisecapture.ui.components.button.ButtonViewModel
+import org.noiseplanet.noisecapture.util.VuMeterOptions
 
 class SoundLevelMeterViewModel(
     val showMinMaxSPL: Boolean = true,
@@ -37,9 +38,6 @@ class SoundLevelMeterViewModel(
          * Tick values will be determined from provided min and max values
          */
         const val VU_METER_TICKS_COUNT: Int = 6
-
-        const val VU_METER_DB_MIN = 20.0
-        const val VU_METER_DB_MAX = 120.0
     }
 
 
@@ -57,7 +55,8 @@ class SoundLevelMeterViewModel(
     )
 
     val vuMeterTicks: IntArray = IntArray(size = VU_METER_TICKS_COUNT) { index ->
-        (VU_METER_DB_MIN + ((VU_METER_DB_MAX - VU_METER_DB_MIN) / (VU_METER_TICKS_COUNT - 1) * index)).toInt()
+        val offset = (VuMeterOptions.DB_MAX - VuMeterOptions.DB_MIN) / (VU_METER_TICKS_COUNT - 1)
+        (VuMeterOptions.DB_MIN + (offset * index)).toInt()
     }
 
     val soundPressureLevelFlow: Flow<Double>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
@@ -17,7 +17,9 @@ import noisecapture.composeapp.generated.resources.sound_level_meter_min_dba
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.audio.AudioSourceState
+import org.noiseplanet.noisecapture.model.dao.LeqMetrics
 import org.noiseplanet.noisecapture.services.audio.LiveAudioService
+import org.noiseplanet.noisecapture.services.measurement.MeasurementService
 import org.noiseplanet.noisecapture.ui.components.button.ButtonStyle
 import org.noiseplanet.noisecapture.ui.components.button.ButtonViewModel
 
@@ -44,6 +46,7 @@ class SoundLevelMeterViewModel(
     // - Properties
 
     private val liveAudioService: LiveAudioService by inject()
+    private val measurementService: MeasurementService by inject()
 
     val playPauseButtonViewModel = ButtonViewModel(
         onClick = this::toggleAudioSource,
@@ -59,6 +62,9 @@ class SoundLevelMeterViewModel(
 
     val soundPressureLevelFlow: Flow<Double>
         get() = liveAudioService.getWeightedLeqFlow()
+
+    val leqMetricsFlow: Flow<LeqMetrics?>
+        get() = measurementService.getOngoingMeasurementLeqMetricsFlow()
 
     val currentDbALabel = Res.string.sound_level_meter_current_dba
     val minDbALabel = Res.string.sound_level_meter_min_dba

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
@@ -17,7 +17,7 @@ import noisecapture.composeapp.generated.resources.sound_level_meter_min_dba
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.audio.AudioSourceState
-import org.noiseplanet.noisecapture.model.dao.LeqMetrics
+import org.noiseplanet.noisecapture.model.dao.LAeqMetrics
 import org.noiseplanet.noisecapture.services.audio.LiveAudioService
 import org.noiseplanet.noisecapture.services.measurement.MeasurementService
 import org.noiseplanet.noisecapture.ui.components.button.ButtonStyle
@@ -63,8 +63,8 @@ class SoundLevelMeterViewModel(
     val soundPressureLevelFlow: Flow<Double>
         get() = liveAudioService.getWeightedLeqFlow()
 
-    val leqMetricsFlow: Flow<LeqMetrics?>
-        get() = measurementService.getOngoingMeasurementLeqMetricsFlow()
+    val laeqMetricsFlow: Flow<LAeqMetrics?>
+        get() = measurementService.getOngoingMeasurementLaeqMetricsFlow()
 
     val currentDbALabel = Res.string.sound_level_meter_current_dba
     val minDbALabel = Res.string.sound_level_meter_min_dba

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
@@ -17,9 +17,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MAX
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel.Companion.VU_METER_DB_MIN
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
+import org.noiseplanet.noisecapture.util.VuMeterOptions
 
 private val BAR_HEIGHT: Dp = 24.dp
 
@@ -27,8 +26,8 @@ private val BAR_HEIGHT: Dp = 24.dp
 fun VuMeter(
     ticks: IntArray,
     value: Double,
-    minimum: Double = VU_METER_DB_MIN,
-    maximum: Double = VU_METER_DB_MAX,
+    minimum: Double = VuMeterOptions.DB_MIN,
+    maximum: Double = VuMeterOptions.DB_MAX,
     modifier: Modifier = Modifier,
 ) {
     val valueRatio = (value - minimum) / (maximum - minimum)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FloatingPointUtil.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FloatingPointUtil.kt
@@ -1,0 +1,38 @@
+package org.noiseplanet.noisecapture.util
+
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+
+/**
+ * Rounds this number to the Nth decimal place.
+ *
+ * Example:
+ * ```kotlin
+ * 10.467.roundTo(1) // -> 10.5
+ * ```
+ *
+ * @param decimalPlaces Number of decimals to keep
+ * @return Rounded number
+ */
+fun Double.roundTo(decimalPlaces: Int): Double {
+    val factor = 10.0.pow(decimalPlaces)
+    return (this * factor).roundToInt() / factor
+}
+
+
+/**
+ * Rounds this number to the Nth decimal place.
+ *
+ * Example:
+ * ```kotlin
+ * 10.467.roundTo(1) // -> 10.5
+ * ```
+ *
+ * @param decimalPlaces Number of decimals to keep
+ * @return Rounded number
+ */
+fun Float.roundTo(decimalPlaces: Int): Float {
+    val factor = 10.0f.pow(decimalPlaces)
+    return (this * factor).roundToInt() / factor
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/VuMeterOptions.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/VuMeterOptions.kt
@@ -1,0 +1,28 @@
+package org.noiseplanet.noisecapture.util
+
+
+/**
+ * Specifies parameters for in app VU meters.
+ */
+object VuMeterOptions {
+
+    /**
+     * Minimum dB threshold for a value to be taken into account.
+     */
+    const val DB_MIN: Double = 20.0
+
+    /**
+     * Maximum dB threshold for a value to be taken into account.
+     */
+    const val DB_MAX: Double = 20.0
+}
+
+
+/**
+ * Tells if this value is in the range supported by in app VU meters.
+ *
+ * @return True if this value is in the range supported by in app VU meters.
+ */
+fun Double.isInVuMeterRange(): Boolean {
+    return this in VuMeterOptions.DB_MIN..VuMeterOptions.DB_MAX
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/VuMeterOptions.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/VuMeterOptions.kt
@@ -14,7 +14,7 @@ object VuMeterOptions {
     /**
      * Maximum dB threshold for a value to be taken into account.
      */
-    const val DB_MAX: Double = 20.0
+    const val DB_MAX: Double = 120.0
 }
 
 


### PR DESCRIPTION
# Description

Show Min / Avg / Max values when recording a new measurement

## Changes

- Calculate Min/Avg/Max values in real time
- Display the values in real time on the measurement screen
- Values are shown color coded like the current SPL value
- When ending the recording, those values are serialised with the rest of the measurement

## Linked issues

- #89

## Remaining TODOs

- Currently the raw Leq value is displayed. Should we instead show the LAeq value so it matches the displayed current value range?

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
