### PR TITLE
Feature/improve weighted spl decaying

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/AcousticIndicatorsProcessing.kt
@@ -10,23 +10,31 @@ import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
 
-const val WINDOW_TIME = 0.125
-
-// https://source.android.com/docs/compatibility/12/android-12-cdd.pdf
-// Android 12
-// Last updated: October 4, 2021
-// SHOULD set audio input sensitivity such that a 1000 Hz sinusoidal tone source played at
-// 90 dB Sound Pressure Level (SPL) yields a response with RMS of 2500 for 16 bit-samples
-// (or -22.35 dB Full Scale for floating point/double precision samples) for each and every
-// microphone used to record the voice recognition audio source.
-const val ANDROID_GAIN = -(-22.35 - 90)
-
 /**
  * TODO: Document this class!
  */
 class AcousticIndicatorsProcessing(val sampleRate: Int, val dbGain: Double = ANDROID_GAIN) {
 
-    private var windowLength = (sampleRate * WINDOW_TIME).toInt()
+    // - Constants
+
+    companion object {
+
+        const val WINDOW_TIME_SECONDS = 0.125
+
+        // https://source.android.com/docs/compatibility/12/android-12-cdd.pdf
+        // Android 12
+        // Last updated: October 4, 2021
+        // SHOULD set audio input sensitivity such that a 1000 Hz sinusoidal tone source played at
+        // 90 dB Sound Pressure Level (SPL) yields a response with RMS of 2500 for 16 bit-samples
+        // (or -22.35 dB Full Scale for floating point/double precision samples) for each and every
+        // microphone used to record the voice recognition audio source.
+        const val ANDROID_GAIN = -(-22.35 - 90)
+    }
+
+
+    // - Properties
+
+    private var windowLength = (sampleRate * WINDOW_TIME_SECONDS).toInt()
     private var windowData = FloatArray(windowLength)
     private var windowDataCursor = 0
     private val nominalFrequencies: List<Int>
@@ -40,6 +48,9 @@ class AcousticIndicatorsProcessing(val sampleRate: Int, val dbGain: Double = AND
         )
         nominalFrequencies = this.getNominalFrequency()
     }
+
+
+    // - Public functions
 
     suspend fun processSamples(samples: AudioSamples): List<AcousticIndicatorsData> {
         val acousticIndicatorsDataList = ArrayList<AcousticIndicatorsData>()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/signal/LevelDisplayWeightedDecay.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/signal/LevelDisplayWeightedDecay.kt
@@ -2,23 +2,37 @@ package org.noiseplanet.noisecapture.audio.signal
 
 import kotlin.math.log10
 import kotlin.math.pow
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
-
-const val FAST_DECAY_RATE = -34.7
-const val SLOW_DECAY_RATE = -4.3
 
 /**
  * IEC 61672-1 standard for displayed sound level decay
  *
- * TODO: Document parameters
+ * @param decibelDecayPerSecond Decibels decay rate.
+ * @param newValueTimeInterval Duration between each new sample.
  */
 class LevelDisplayWeightedDecay(
     decibelDecayPerSecond: Double,
-    newValueTimeInterval: Double,
+    newValueTimeInterval: Duration,
 ) {
+    // - Constants
 
-    private val timeWeight = 10.0.pow(decibelDecayPerSecond * newValueTimeInterval / 10.0)
+    companion object {
+
+        const val FAST_DECAY_RATE = -34.7
+        const val SLOW_DECAY_RATE = -4.3
+    }
+
+
+    // - Properties
+
+    private val timeIntervalSeconds = newValueTimeInterval.toDouble(unit = DurationUnit.SECONDS)
+    private val timeWeight = 10.0.pow(decibelDecayPerSecond * timeIntervalSeconds / 10.0)
     private var timeIntegration = 0.0
+
+
+    // - Public functions
 
     /**
      * TODO: add documentation
@@ -28,5 +42,4 @@ class LevelDisplayWeightedDecay(
             10.0.pow(newValue / 10.0) * (1 - timeWeight)
         return 10 * log10(timeIntegration)
     }
-
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/ServicesModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/ServicesModule.kt
@@ -26,9 +26,7 @@ val servicesModule = module {
     }
 
     single<LiveAudioService> {
-        DefaultLiveAudioService(
-            audioSource = get(),
-        )
+        DefaultLiveAudioService()
     }
 
     single<UserSettingsService> {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/LiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/LiveAudioService.kt
@@ -3,13 +3,34 @@ package org.noiseplanet.noisecapture.services.audio
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.noiseplanet.noisecapture.audio.AcousticIndicatorsData
+import org.noiseplanet.noisecapture.audio.AcousticIndicatorsProcessing
 import org.noiseplanet.noisecapture.audio.AudioSourceState
+import org.noiseplanet.noisecapture.audio.signal.LevelDisplayWeightedDecay
 import org.noiseplanet.noisecapture.audio.signal.window.SpectrumData
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 /**
  * Listen to incoming audio and process samples to extract some acoustic indicators.
  */
 interface LiveAudioService {
+
+    // - Constants
+
+    companion object {
+
+        protected const val DEFAULT_WEIGHTED_SPL_DECAY_RATE: Double =
+            LevelDisplayWeightedDecay.FAST_DECAY_RATE
+
+        protected val DEFAULT_WEIGHTED_SPL_WINDOW_TIME: Duration =
+            AcousticIndicatorsProcessing.WINDOW_TIME_SECONDS.toDuration(
+                unit = DurationUnit.SECONDS
+            )
+    }
+
+
+    // - Properties
 
     /**
      * True if service is currently monitoring incoming audio,
@@ -32,6 +53,9 @@ interface LiveAudioService {
      * A flow of [audioSourceState] values.
      */
     val audioSourceStateFlow: Flow<AudioSourceState>
+
+
+    // - Public functions
 
     /**
      * Setup audio source for listening to incoming audio.
@@ -62,13 +86,25 @@ interface LiveAudioService {
 
     /**
      * Get a [Flow] of sound pressure level values.
+     *
+     * @param splDecayRate Decibels decay per second.
+     * @param windowTime Time interval between samples.
      */
-    fun getWeightedLeqFlow(): Flow<Double>
+    fun getWeightedLeqFlow(
+        splDecayRate: Double = DEFAULT_WEIGHTED_SPL_DECAY_RATE,
+        windowTime: Duration = DEFAULT_WEIGHTED_SPL_WINDOW_TIME,
+    ): Flow<Double>
 
     /**
      * Get a [Flow] of sound pressure levels weighted by frequency band.
+     *
+     * @param splDecayRate Decibels decay per second.
+     * @param windowTime Time interval between samples.
      */
-    fun getWeightedSoundPressureLevelFlow(): Flow<Map<Int, Double>>
+    fun getWeightedLeqPerFrequencyBandFlow(
+        splDecayRate: Double = DEFAULT_WEIGHTED_SPL_DECAY_RATE,
+        windowTime: Duration = DEFAULT_WEIGHTED_SPL_WINDOW_TIME,
+    ): Flow<Map<Int, Double>>
 
     /**
      * Get a [Flow] of [SpectrumData] from the currently running recording.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -1,5 +1,6 @@
 package org.noiseplanet.noisecapture.ui.components.spl
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,7 +42,7 @@ fun SoundLevelMeterView() {
     val playPauseButtonViewModel by viewModel.playPauseButtonViewModelFlow
         .collectAsStateWithLifecycle()
 
-    val currentSplColor = NoiseLevelColorRamp.getColorForSPLValue(currentSpl)
+    val currentSplColor by animateColorAsState(NoiseLevelColorRamp.getColorForSPLValue(currentSpl))
 
 
     // - Layout

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -14,28 +14,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.ui.components.button.NCButton
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
+import org.noiseplanet.noisecapture.ui.theme.NotoSansMono
 import org.noiseplanet.noisecapture.util.isInVuMeterRange
-import org.noiseplanet.noisecapture.util.roundTo
 
 
 @Composable
-fun SoundLevelMeterView(
-    viewModel: SoundLevelMeterViewModel,
-) {
+fun SoundLevelMeterView() {
+
     // - Properties
 
-    val currentSoundPressureLevel by viewModel.soundPressureLevelFlow.collectAsStateWithLifecycle()
-    val roundedSpl = currentSoundPressureLevel.roundTo(1)
+    val viewModel: SoundLevelMeterViewModel = koinViewModel()
 
-    val currentLeqMetrics by viewModel.laeqMetricsFlow.collectAsStateWithLifecycle()
-    val playPauseButtonViewModel by viewModel.playPauseButtonViewModelFlow.collectAsStateWithLifecycle()
+    val currentSpl by viewModel.soundPressureLevelFlow
+        .collectAsStateWithLifecycle()
+    val currentLeqMetrics by viewModel.laeqMetricsFlow
+        .collectAsStateWithLifecycle()
+    val playPauseButtonViewModel by viewModel.playPauseButtonViewModelFlow
+        .collectAsStateWithLifecycle()
+
+    val currentSplColor = NoiseLevelColorRamp.getColorForSPLValue(currentSpl)
 
 
     // - Layout
@@ -59,11 +65,12 @@ fun SoundLevelMeterView(
                     )
 
                     Text(
-                        text = if (roundedSpl.isInVuMeterRange()) roundedSpl.toString() else "-",
+                        text = if (currentSpl.isInVuMeterRange()) currentSpl.toString() else "-",
                         style = MaterialTheme.typography.headlineLarge.copy(
                             fontWeight = FontWeight.Black,
+                            fontFamily = FontFamily.NotoSansMono,
                             fontSize = 36.sp,
-                            color = NoiseLevelColorRamp.getColorForSPLValue(roundedSpl)
+                            color = currentSplColor
                         )
                     )
                 }
@@ -83,7 +90,7 @@ fun SoundLevelMeterView(
 
             VuMeter(
                 ticks = viewModel.vuMeterTicks,
-                value = currentSoundPressureLevel,
+                valueFlow = viewModel.soundPressureLevelFlow,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
@@ -20,6 +20,7 @@ import org.noiseplanet.noisecapture.ui.components.button.IconNCButtonViewModel
 import org.noiseplanet.noisecapture.ui.components.button.NCButtonColors
 import org.noiseplanet.noisecapture.ui.components.button.NCButtonViewModel
 import org.noiseplanet.noisecapture.util.VuMeterOptions
+import org.noiseplanet.noisecapture.util.roundTo
 import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
 
 
@@ -58,19 +59,20 @@ class SoundLevelMeterViewModel(
         (VuMeterOptions.DB_MIN + (offset * index)).toInt()
     }
 
-    val soundPressureLevelFlow: StateFlow<Double>
-        get() = liveAudioService.getWeightedLeqFlow()
-            .stateInWhileSubscribed(
-                scope = viewModelScope,
-                initialValue = 0.0,
-            )
+    val soundPressureLevelFlow: StateFlow<Double> = liveAudioService
+        .getWeightedLeqFlow()
+        .map { it.roundTo(1) }
+        .stateInWhileSubscribed(
+            scope = viewModelScope,
+            initialValue = 0.0,
+        )
 
-    val laeqMetricsFlow: StateFlow<LAeqMetrics?>
-        get() = measurementService.getOngoingMeasurementLaeqMetricsFlow()
-            .stateInWhileSubscribed(
-                scope = viewModelScope,
-                initialValue = null,
-            )
+    val laeqMetricsFlow: StateFlow<LAeqMetrics?> = measurementService
+        .getOngoingMeasurementLaeqMetricsFlow()
+        .stateInWhileSubscribed(
+            scope = viewModelScope,
+            initialValue = null,
+        )
 
     val currentDbALabel = Res.string.sound_level_meter_current_dba
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
@@ -1,5 +1,6 @@
 package org.noiseplanet.noisecapture.ui.components.spl
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
@@ -40,7 +41,7 @@ fun VuMeter(
     val value: Double by valueFlow.collectAsStateWithLifecycle()
     val valueRatio = (value - minimum) / (maximum - minimum)
 
-    val color = NoiseLevelColorRamp.getColorForSPLValue(value)
+    val color by animateColorAsState(NoiseLevelColorRamp.getColorForSPLValue(value))
     val shape = RoundedCornerShape(
         topStartPercent = 0,
         bottomStartPercent = 0,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
@@ -1,6 +1,8 @@
 package org.noiseplanet.noisecapture.ui.components.spl
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,11 +14,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
 import org.noiseplanet.noisecapture.util.VuMeterOptions
 
@@ -25,12 +30,16 @@ private val BAR_HEIGHT: Dp = 24.dp
 @Composable
 fun VuMeter(
     ticks: IntArray,
-    value: Double,
+    valueFlow: StateFlow<Double>,
     minimum: Double = VuMeterOptions.DB_MIN,
     maximum: Double = VuMeterOptions.DB_MAX,
     modifier: Modifier = Modifier,
 ) {
+    // - Properties
+
+    val value: Double by valueFlow.collectAsStateWithLifecycle()
     val valueRatio = (value - minimum) / (maximum - minimum)
+
     val color = NoiseLevelColorRamp.getColorForSPLValue(value)
     val shape = RoundedCornerShape(
         topStartPercent = 0,
@@ -39,19 +48,27 @@ fun VuMeter(
         bottomEndPercent = 50
     )
 
+
+    // - Layout
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         // Bar
-        Row(modifier = Modifier.fillMaxWidth()) {
-            Box(
-                modifier = Modifier.fillMaxWidth(valueRatio.toFloat()).animateContentSize()
-                    .height(BAR_HEIGHT)
-                    .clip(shape)
-                    .background(color)
-            )
-        }
+        Box(
+            modifier = Modifier
+                .clip(shape)
+                .background(color)
+                .animateContentSize(
+                    animationSpec = tween(
+                        durationMillis = 125,
+                        easing = EaseOut
+                    )
+                )
+                .fillMaxWidth(valueRatio.toFloat())
+                .height(BAR_HEIGHT)
+        )
 
         // Ticks
         Row(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/SoundLevelMeterHeaderView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/SoundLevelMeterHeaderView.kt
@@ -13,10 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.ui.components.button.NCButton
 import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterView
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel
 
 
 @Composable
@@ -24,17 +22,12 @@ fun SoundLevelMeterHeaderView(
     viewModel: HomeScreenViewModel,
     onClickOpenSoundLevelMeterButton: () -> Unit,
 ) {
-    // - Properties
-
-    val soundLevelMeterViewModel: SoundLevelMeterViewModel = koinViewModel()
-
-
     // - Layout
 
     Column(
         modifier = Modifier.background(MaterialTheme.colorScheme.background)
     ) {
-        SoundLevelMeterView(soundLevelMeterViewModel)
+        SoundLevelMeterView()
 
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingScreen.kt
@@ -13,10 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import org.koin.compose.module.rememberKoinModules
-import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterView
-import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterViewModel
 import org.noiseplanet.noisecapture.ui.features.recording.controls.RecordingControls
 
 
@@ -33,11 +31,6 @@ fun MeasurementRecordingScreen(
     }
 
 
-    // - Properties
-
-    val soundLevelMeterViewModel: SoundLevelMeterViewModel = koinViewModel()
-
-
     // - Layout
 
     Surface(
@@ -48,7 +41,7 @@ fun MeasurementRecordingScreen(
             if (maxWidth > maxHeight) {
                 Row(modifier = Modifier.fillMaxSize()) {
                     Column(modifier = Modifier.fillMaxWidth(.5F)) {
-                        SoundLevelMeterView(viewModel = soundLevelMeterViewModel)
+                        SoundLevelMeterView()
                         RecordingControls(onMeasurementDone)
                     }
                     Column(modifier = Modifier) {
@@ -57,7 +50,7 @@ fun MeasurementRecordingScreen(
                 }
             } else {
                 Column {
-                    SoundLevelMeterView(viewModel = soundLevelMeterViewModel)
+                    SoundLevelMeterView()
                     MeasurementRecordingPager(modifier = Modifier.fillMaxWidth().weight(1f))
                     RecordingControls(onMeasurementDone)
                 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrogram/SpectrogramPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrogram/SpectrogramPlotViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import org.noiseplanet.noisecapture.audio.ANDROID_GAIN
+import org.noiseplanet.noisecapture.audio.AcousticIndicatorsProcessing
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.enums.SpectrogramScaleMode
 import org.noiseplanet.noisecapture.services.audio.LiveAudioService
@@ -27,8 +27,10 @@ class SpectrogramPlotViewModel : ViewModel(), KoinComponent {
 
         private const val RANGE_DB = 40.0
         private const val MIN_DB = 0.0
-        private const val DB_GAIN = ANDROID_GAIN // TODO: Platform dependant gain?
         private const val DEFAULT_SAMPLE_RATE = 48000.0
+
+        // TODO: Platform dependant gain?
+        private const val DB_GAIN = AcousticIndicatorsProcessing.ANDROID_GAIN
 
         const val REFERENCE_LEGEND_TEXT = " +99s "
         const val SPECTROGRAM_STRIP_WIDTH = 32

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
@@ -51,7 +51,7 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
         )
 
     val weightedSplFlow: StateFlow<Map<Int, Double>> = liveAudioService
-        .getWeightedSoundPressureLevelFlow()
+        .getWeightedLeqPerFrequencyBandFlow()
         .stateInWhileSubscribed(
             scope = viewModelScope,
             initialValue = emptyMap()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FlowUtil.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/FlowUtil.kt
@@ -1,28 +1,40 @@
 package org.noiseplanet.noisecapture.util
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.transform
 
 
 /**
- * Throttles the values emitted by this flow so that one value is emitted every fixed delay.
+ * Throttles the values emitted by this flow so that one value is emitted every fixed delay, while
+ * still emitting the first available value as soon as possible if wanted.
+ *
  * Note that if an element is emitted during the delay period, it will still be emitted once the
  * delay has elapsed and not be dropped. If two elements or more are emitted during the delay period,
  * only the last element will by emitted once the delay has elapsed.
  *
  * @param delayMillis Milliseconds delay between each emitted element.
+ * @param emitFirstValue If true, emits the first value coming from this flow instantly, then
+ *                       throttles following values.
  */
-fun <T> Flow<T>.throttleLatest(delayMillis: Long) = this
-    .conflate()
-    .transform {
-        emit(it)
-        delay(delayMillis)
-    }
+@OptIn(FlowPreview::class)
+fun <T> Flow<T>.throttleLatest(delayMillis: Long, emitFirstValue: Boolean = true): Flow<T> {
+    var firstEmit = emitFirstValue
+
+    return merge(flow {
+        this@throttleLatest.collect { value ->
+            if (firstEmit) {
+                emit(value)
+                firstEmit = false
+            }
+        }
+    }, this.sample(delayMillis))
+}
 
 
 /**


### PR DESCRIPTION
# Description

Fixes the smooth displaying of current sound level using `LevelWeightedDisplayDecay`.

## Changes

- Fixed `LiveAudioSource.soundPressureLevelFlow` being recreated at every recomposition, meaning `LevelWeightedDisplayDecay` was also recreated.
- Use a monospace font for displaying current level to improve readability
- Added animations to bar length and color to smooth out transitions between values
- Made it possible to pass a custom decay rate and window time to `LiveAudioSource` so that different views can use different refresh rates (Spectrum and SoundLevelMeter for instance), but for now both are set to the same 125ms / -34dB.
- Small refactor here and there, added some parameters documentation

## Linked issues

N/A

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
