### PR TITLE
Fix/persistent storage

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -1,4 +1,3 @@
-import kotlinx.browser.window
 import org.noiseplanet.noisecapture.interop.navigator
 import org.noiseplanet.noisecapture.model.dao.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
@@ -33,11 +32,6 @@ class WasmJSPlatform : Platform {
                 Permission.RECORD_AUDIO,
                 Permission.LOCATION_BACKGROUND,
             )
-            if (window.location.protocol == "https:") {
-                // Required for persistent storage using OPFS but only available in a
-                // secure connection https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist
-                return permissions.plus(Permission.PERSISTENT_LOCAL_STORAGE)
-            }
             return permissions
         }
 }


### PR DESCRIPTION
# Description

Disables persistent storage permission check on web.

## Changes

Not all browsers support a proper way of asking user for using persistent local storage (Safari iOS and Chrome at least). So for now we will just rely on "best effort" storage, meaning measurements might get deleted if storage space is running low.

I'm hoping that it will not randomly delete files and thus compromise measurements integrity, but if its the case we can work on a storage cleanup mechanism if necessary.

This PR is targetting a `version/0.4.1` branch, I will make a new release once it is merged to avoid blocking the web version until the next important release. I've opened an issue to show a welcome popup inviting users to install the app for a better experience.

## Linked issues

- #112 

## Remaining TODOs

- #118 

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [ ] Added code has been documented
