### PR TITLE
Fix/leq instead of laeq

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/DefaultLiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/DefaultLiveAudioService.kt
@@ -149,7 +149,7 @@ class DefaultLiveAudioService : LiveAudioService, KoinComponent {
 
         return getAcousticIndicatorsFlow()
             .map {
-                levelDisplay.getWeightedValue(it.leq)
+                levelDisplay.getWeightedValue(it.laeq)
             }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/LiveAudioService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/audio/LiveAudioService.kt
@@ -2,11 +2,11 @@ package org.noiseplanet.noisecapture.services.audio
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import org.noiseplanet.noisecapture.audio.AcousticIndicatorsData
 import org.noiseplanet.noisecapture.audio.AcousticIndicatorsProcessing
 import org.noiseplanet.noisecapture.audio.AudioSourceState
 import org.noiseplanet.noisecapture.audio.signal.LevelDisplayWeightedDecay
 import org.noiseplanet.noisecapture.audio.signal.window.SpectrumData
+import org.noiseplanet.noisecapture.model.dao.LeqRecord
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -80,9 +80,9 @@ interface LiveAudioService {
     fun stopListening()
 
     /**
-     * Get a [Flow] of [AcousticIndicatorsData] from the currently running recording.
+     * Get a [Flow] of [LeqRecord] from the currently running recording.
      */
-    fun getAcousticIndicatorsFlow(): Flow<AcousticIndicatorsData>
+    fun getLeqRecordsFlow(): Flow<LeqRecord>
 
     /**
      * Get a [Flow] of sound pressure level values.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementRecordingService.kt
@@ -17,7 +17,6 @@ import kotlinx.datetime.format.byUnicodePattern
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.log.Logger
-import org.noiseplanet.noisecapture.model.dao.LeqRecord
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationSequenceFragment
 import org.noiseplanet.noisecapture.services.audio.AudioRecordingService
@@ -172,18 +171,8 @@ open class DefaultMeasurementRecordingService : MeasurementRecordingService, Koi
 
                 // Subscribe to
                 launch {
-                    liveAudioService.getAcousticIndicatorsFlow().collect { indicators ->
-                        // TODO: This could be done already in LiveAudioService?
-                        // Map acoustic indicators to LeqRecord
-                        val leqRecord = LeqRecord(
-                            // TODO: Properly fill LZeq and LCeq
-                            timestamp = Clock.System.now().toEpochMilliseconds(),
-                            lzeq = indicators.leq,
-                            laeq = indicators.laeq,
-                            lceq = indicators.laeq,
-                            leqsPerThirdOctave = indicators.leqsPerThirdOctave
-                        )
-                        measurementService.pushToOngoingMeasurement(leqRecord)
+                    liveAudioService.getLeqRecordsFlow().collect {
+                        measurementService.pushToOngoingMeasurement(it)
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
@@ -43,7 +43,7 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
     }
 
     val rawSplFlow: StateFlow<Map<Int, Double>> = liveAudioService
-        .getAcousticIndicatorsFlow()
+        .getLeqRecordsFlow()
         .map { it.leqsPerThirdOctave }
         .stateInWhileSubscribed(
             scope = viewModelScope,
@@ -58,7 +58,7 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
         )
 
     val axisSettingsFlow: StateFlow<AxisSettings> = liveAudioService
-        .getAcousticIndicatorsFlow()
+        .getLeqRecordsFlow()
         .map { it.leqsPerThirdOctave.keys.toList() }
         .distinctUntilChanged()
         .map {

--- a/composeApp/src/commonTest/kotlin/org/noiseplanet/noisecapture/signal/TestWindowAnalysis.kt
+++ b/composeApp/src/commonTest/kotlin/org/noiseplanet/noisecapture/signal/TestWindowAnalysis.kt
@@ -250,7 +250,7 @@ class TestWindowAnalysis {
         val processed = acousticIndicatorProcessing.processSamples(
             AudioSamples(0, signal, sampleRate)
         )
-        val averageLeq = processed.map { indicators -> indicators.leq }.average()
+        val averageLeq = processed.map { indicators -> indicators.lzeq }.average()
         assertEquals(expectedLevel, averageLeq, 0.01)
     }
 }


### PR DESCRIPTION
# Description

Current dB now shows Laeq instead of Leq

## Changes

- Show correct value as current
- Refactored `AcousticIndicatorsProcessing` to directly output `LeqRecord` objects instead of passing by an intermediary `AcousticIndicatorsData` object that would be transformed further down the line.

## Linked issues

- #124 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
