### PR TITLE
Feature/delete confiramtion popup

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -61,6 +61,9 @@
     <string name="measurement_details_total_size">Total measurement size: </string>
     <string name="measurement_details_delete_measurement_button">Delete measurement</string>
     <string name="measurement_details_delete_measurement_audio_button">Delete recorded audio</string>
+    <string name="measurement_details_delete_measurement_dialog_title">Are you sure?</string>
+    <string name="measurement_details_delete_measurement_dialog_text">This action cannot be undone. Note that this will only the local copy of your measurement, if you've already synced it before, the distant copy will be kept but you won't be able to download it again.</string>
+    <string name="measurement_details_delete_measurement_audio_dialog_text">This action cannot be undone. This will not delete the measurement itself but only the audio clip that is attached to it. You won't be able to listen to the measurement audio afterwards but will still be able to see the measurement details.</string>
 
 
     <!-- Settings -->
@@ -157,4 +160,6 @@
 
     <!-- Misc -->
     <string name="na">N/A</string>
+    <string name="delete">Delete</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/ManageMeasurementView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/ManageMeasurementView.kt
@@ -6,23 +6,36 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import nl.jacobras.humanreadable.HumanReadable
 import noisecapture.composeapp.generated.resources.Res
+import noisecapture.composeapp.generated.resources.cancel
+import noisecapture.composeapp.generated.resources.delete
 import noisecapture.composeapp.generated.resources.measurement_details_audio_size
+import noisecapture.composeapp.generated.resources.measurement_details_delete_measurement_audio_dialog_text
+import noisecapture.composeapp.generated.resources.measurement_details_delete_measurement_dialog_text
+import noisecapture.composeapp.generated.resources.measurement_details_delete_measurement_dialog_title
 import noisecapture.composeapp.generated.resources.measurement_details_manage_description
 import noisecapture.composeapp.generated.resources.measurement_details_manage_title
 import noisecapture.composeapp.generated.resources.measurement_details_total_size
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.ui.components.button.NCButton
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonColors
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonStyle
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonViewModel
 
 
 @Composable
@@ -37,6 +50,14 @@ fun ManageMeasurementView(
         parametersOf(measurementId)
     }
     val viewState by viewModel.viewStateFlow.collectAsStateWithLifecycle()
+
+    var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
+    var deleteConfirmationText by remember {
+        mutableStateOf(Res.string.measurement_details_delete_measurement_dialog_text)
+    }
+    var deleteConfirmationAction: (() -> Unit)? by remember {
+        mutableStateOf(null)
+    }
 
 
     // - Layout
@@ -83,7 +104,12 @@ fun ManageMeasurementView(
                 state.deleteAudioButtonViewModel?.let { buttonViewModel ->
                     NCButton(
                         viewModel = buttonViewModel,
-                        onClick = viewModel::deleteMeasurementAudio,
+                        onClick = {
+                            deleteConfirmationText =
+                                Res.string.measurement_details_delete_measurement_audio_dialog_text
+                            deleteConfirmationAction = viewModel::deleteMeasurementAudio
+                            showDeleteConfirmationDialog = true
+                        },
                         modifier = Modifier.fillMaxWidth()
                             .padding(horizontal = 48.dp)
                     )
@@ -91,7 +117,12 @@ fun ManageMeasurementView(
 
                 NCButton(
                     viewModel = state.deleteMeasurementButtonViewModel,
-                    onClick = viewModel::deleteMeasurement,
+                    onClick = {
+                        deleteConfirmationText =
+                            Res.string.measurement_details_delete_measurement_dialog_text
+                        deleteConfirmationAction = viewModel::deleteMeasurement
+                        showDeleteConfirmationDialog = true
+                    },
                     modifier = Modifier.fillMaxWidth()
                         .padding(horizontal = 48.dp)
                 )
@@ -100,4 +131,62 @@ fun ManageMeasurementView(
 
         else -> return
     }
+
+    if (showDeleteConfirmationDialog) {
+        DeleteConfirmationDialog(
+            title = Res.string.measurement_details_delete_measurement_dialog_title,
+            text = deleteConfirmationText,
+            onDismissRequest = { showDeleteConfirmationDialog = false },
+            onConfirm = {
+                deleteConfirmationAction?.let { it() }
+                showDeleteConfirmationDialog = false
+            }
+        )
+    }
+}
+
+
+@Composable
+private fun DeleteConfirmationDialog(
+    title: StringResource,
+    text: StringResource,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    // - Properties
+
+    val confirmButtonViewModel = NCButtonViewModel(
+        title = Res.string.delete,
+        style = NCButtonStyle.TEXT,
+        colors = {
+            NCButtonColors.Defaults.text()
+                .copy(contentColor = MaterialTheme.colorScheme.error)
+        },
+    )
+    val cancelButtonViewModel = NCButtonViewModel(
+        title = Res.string.cancel,
+        style = NCButtonStyle.TEXT,
+        colors = {
+            NCButtonColors.Defaults.text()
+        },
+    )
+
+
+    // - Layout
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            NCButton(onClick = onConfirm, viewModel = confirmButtonViewModel)
+        },
+        dismissButton = {
+            NCButton(onClick = onDismissRequest, viewModel = cancelButtonViewModel)
+        },
+        title = {
+            Text(stringResource(title))
+        },
+        text = {
+            Text(stringResource(text))
+        },
+    )
 }


### PR DESCRIPTION
# Description

Show a confirmation dialog before deleting a measurement or its audio

## Changes

- Added `AlertDialog` to `ManageMeasurementView` when clicking one of the delete buttons. Content and actions will depend on which button is pressed.

## Linked issues

- #116 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
