### PR TITLE
Feature/composable spectrum

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrogram.SpectrogramPlotView
-import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum.SpectrumPlotViewCompose
+import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum.SpectrumPlotView
 
 /**
  * A horizontal pager on the measurement recording screens that allows user to switch between
@@ -60,7 +60,7 @@ fun MeasurementRecordingPager(
                 }
 
                 MeasurementTabState.SPECTRUM -> Box {
-                    SpectrumPlotViewCompose()
+                    SpectrumPlotView()
                 }
 
                 else -> Surface(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
@@ -2,6 +2,7 @@ package org.noiseplanet.noisecapture.ui.features.recording
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrogram.SpectrogramPlotView
@@ -60,7 +62,7 @@ fun MeasurementRecordingPager(
                 }
 
                 MeasurementTabState.SPECTRUM -> Box {
-                    SpectrumPlotView()
+                    SpectrumPlotView(modifier = Modifier.padding(horizontal = 16.dp))
                 }
 
                 else -> Surface(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrogram.SpectrogramPlotView
-import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum.SpectrumPlotView
+import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum.SpectrumPlotViewCompose
 
 /**
  * A horizontal pager on the measurement recording screens that allows user to switch between
@@ -60,9 +60,7 @@ fun MeasurementRecordingPager(
                 }
 
                 MeasurementTabState.SPECTRUM -> Box {
-                    SpectrumPlotView(
-                        viewModel = koinViewModel(),
-                    )
+                    SpectrumPlotViewCompose()
                 }
 
                 else -> Surface(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/MeasurementRecordingPager.kt
@@ -62,7 +62,7 @@ fun MeasurementRecordingPager(
                 }
 
                 MeasurementTabState.SPECTRUM -> Box {
-                    SpectrumPlotView(modifier = Modifier.padding(horizontal = 16.dp))
+                    SpectrumPlotView(modifier = Modifier.padding(start = 8.dp, end = 16.dp))
                 }
 
                 else -> Surface(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -173,10 +174,10 @@ private fun SpectrumPlotYAxisGrid(
     strokeWidth: Dp = 2.dp,
 ) = Canvas(modifier = Modifier.fillMaxSize()) {
     val strokeWidthPx = strokeWidth.toPx()
-    val yOffsetStep = size.height / yAxisTicks
+    val yOffsetStep = (size.height + strokeWidthPx) / yAxisTicks
     var yOffset = yOffsetStep - strokeWidthPx / 2f
 
-    repeat(yAxisTicks) {
+    repeat(yAxisTicks - 1) {
         drawLine(
             color = lineColor,
             start = Offset(0f, yOffset),
@@ -197,6 +198,11 @@ private fun SpectrumPlotContainer(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    // - Properties
+
+    val xAxisTicksHeight = 12.dp
+
+
     // - Layout
 
     Row(
@@ -205,16 +211,13 @@ private fun SpectrumPlotContainer(
     ) {
         // Y axis
         Column(
-            verticalArrangement = Arrangement.SpaceEvenly,
+            verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.End,
-            modifier = Modifier.fillMaxHeight().padding(bottom = 36.dp)
+            modifier = Modifier.fillMaxHeight()
+                .padding(bottom = xAxisTicksHeight + 4.dp)
         ) {
             for (freq in axisSettings.nominalFrequencies.reversed()) {
-                Text(
-                    text = freq.toFrequencyString(),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                AxisTickLabel(text = freq.toFrequencyString())
             }
         }
 
@@ -232,18 +235,23 @@ private fun SpectrumPlotContainer(
             Row(
                 verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.height(32.dp).fillMaxWidth()
+                modifier = Modifier.height(xAxisTicksHeight).fillMaxWidth()
             ) {
                 val tickStep = (axisSettings.maximumX / axisSettings.xTicksCount).toInt()
                 val tickRange = axisSettings.minimumX.toInt()..axisSettings.maximumX.toInt()
                 for (tick in tickRange step tickStep) {
-                    Text(
-                        text = "$tick dB",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    AxisTickLabel(text = "$tick dB")
                 }
             }
         }
     }
 }
+
+
+@Composable
+private fun AxisTickLabel(text: String) = Text(
+    text = text,
+    style = MaterialTheme.typography.labelSmall,
+    fontWeight = FontWeight.SemiBold,
+    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
@@ -2,6 +2,7 @@ package org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -14,13 +15,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -29,11 +33,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.viewmodel.koinViewModel
 import org.noiseplanet.noisecapture.util.toFrequencyString
 import kotlin.math.max
-import kotlin.math.min
 
 
 @Composable
-fun SpectrumPlotViewCompose(
+fun SpectrumPlotView(
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     modifier: Modifier = Modifier,
 ) {
@@ -44,9 +47,27 @@ fun SpectrumPlotViewCompose(
     val axisSettings by viewModel.axisSettingsFlow.collectAsStateWithLifecycle()
     val splData by viewModel.splDataFlow.collectAsStateWithLifecycle()
 
-    val gradientBrush = Brush.horizontalGradient(
-        *viewModel.spectrumColorRamp.toTypedArray()
-    )
+    // How wide is each frequency band bar relative to the width of the plot width
+    val rawSplBarWidths by derivedStateOf {
+        splData.mapValues { (_, spl) ->
+            (spl.raw / axisSettings.maximumX).toFloat()
+        }.values.reversed()
+    }
+
+    // Offset of each weighted spl value per frequency band (-1 is left aligned, 1 is right aligned)
+    val weightedSplBoxBiases by derivedStateOf {
+        splData.mapValues { (_, spl) ->
+            ((max(spl.weighted, spl.raw) / axisSettings.maximumX) * 2.0 - 1.0).toFloat()
+        }.values.reversed()
+    }
+
+    // Gradient brush to paint the plot background
+    val gradientBrush = remember {
+        Brush.horizontalGradient(
+            *viewModel.spectrumColorRamp.toTypedArray()
+        )
+    }
+
 
     // - Layout
 
@@ -58,15 +79,11 @@ fun SpectrumPlotViewCompose(
                 .background(gradientBrush)
         ) {
             // 2. Adjust bars size by clipping from the end of the screen (i.e. drawing the negative)
-            for (spl in splData.values.reversed()) {
-                val widthFraction =
-                    (min(spl.raw, axisSettings.maximumX) / axisSettings.maximumX).toFloat()
+            for (widthFraction in rawSplBarWidths) {
                 Box(
                     modifier = Modifier.weight(1f)
                         .background(backgroundColor)
-                        .animateContentSize(
-                            tween(durationMillis = 200, easing = EaseOutBack)
-                        )
+                        .animateContentSize(tween(easing = EaseOutBack, durationMillis = 400))
                         .fillMaxWidth(fraction = 1f - widthFraction)
                 )
             }
@@ -81,30 +98,23 @@ fun SpectrumPlotViewCompose(
 
         // 4. Draw dark rectangles to show weighted spl values
         Column(
-            verticalArrangement = Arrangement.spacedBy(2.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
             modifier = Modifier.fillMaxSize()
         ) {
-            for (spl in splData.values.reversed()) {
-                val widthFraction = (max(spl.weighted, spl.raw) / axisSettings.maximumX).toFloat()
-                val boxColor = MaterialTheme.colorScheme.onSurface
+            val boxColor = MaterialTheme.colorScheme.onSurface
+
+            weightedSplBoxBiases.forEach { bias ->
+                val animatedBias by animateFloatAsState(
+                    targetValue = bias,
+                    animationSpec = tween(easing = EaseOutBack, durationMillis = 400)
+                )
 
                 Box(
-                    modifier = Modifier.weight(1f)
-                        .background(Color.Transparent)
-                        .animateContentSize(
-                            tween(durationMillis = 200, easing = EaseOutBack)
-                        )
-                        .fillMaxWidth(fraction = widthFraction)
-                        .drawBehind {
-                            val boxWidth = 10.dp.toPx()
-                            drawRe
-                            drawRect(
-                                color = boxColor,
-                                start = Offset(size.width, 0f),
-                                end = Offset(size.width, size.height),
-                                strokeWidth = boxWidth
-                            )
-                        }
+                    modifier = Modifier.width(10.dp)
+                        .padding(bottom = 2.dp)
+                        .weight(1f)
+                        .background(boxColor)
+                        .align(BiasAlignment.Horizontal(animatedBias))
                 )
             }
         }
@@ -112,6 +122,9 @@ fun SpectrumPlotViewCompose(
 }
 
 
+/**
+ * Lays out a grid of given X and Y lines with given line color.
+ */
 @Composable
 private fun SpectrumPlotAxisGrid(
     xAxisTicks: Int,
@@ -121,7 +134,7 @@ private fun SpectrumPlotAxisGrid(
     val strokeWidth = 2.dp.toPx()
     val yOffsetStep = size.height / yAxisTicks
     var yOffset = yOffsetStep - strokeWidth / 2f
-    repeat(yAxisTicks - 1) {
+    repeat(yAxisTicks) {
         drawLine(
             color = lineColor,
             start = Offset(0f, yOffset),
@@ -146,6 +159,9 @@ private fun SpectrumPlotAxisGrid(
 }
 
 
+/**
+ * Lays out X and Y axes with given content.
+ */
 @Composable
 private fun SpectrumPlotContainer(
     axisSettings: SpectrumPlotViewModel.AxisSettings,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -234,6 +235,7 @@ private fun SpectrumPlotContainer(
             ) {
                 val tickStep = (axisSettings.maximumX / axisSettings.xTicksCount).toInt()
                 val tickRange = axisSettings.minimumX.toInt()..axisSettings.maximumX.toInt()
+                val tickCount = tickRange.last / tickStep
 
                 // Ticks
                 Row(
@@ -252,11 +254,23 @@ private fun SpectrumPlotContainer(
                 // Tick labels
                 Row(
                     verticalAlignment = Alignment.Top,
-                    horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier.weight(1f).fillMaxWidth()
                 ) {
-                    for (tick in tickRange step tickStep) {
-                        AxisTickLabel(text = "$tick dB")
+                    (tickRange step tickStep).forEachIndexed { index, tick ->
+                        AxisTickLabel(
+                            text = "$tick dB",
+                            textAlign = when (index) {
+                                0 -> TextAlign.Start
+                                tickCount -> TextAlign.End
+                                else -> TextAlign.Center
+                            },
+                            modifier = Modifier.weight(
+                                when (index) {
+                                    0, tickCount -> 0.5f
+                                    else -> 1.0f
+                                }
+                            ),
+                        )
                     }
                 }
             }
@@ -266,9 +280,15 @@ private fun SpectrumPlotContainer(
 
 
 @Composable
-private fun AxisTickLabel(text: String) = Text(
+private fun AxisTickLabel(
+    text: String,
+    textAlign: TextAlign = TextAlign.Unspecified,
+    modifier: Modifier = Modifier,
+) = Text(
     text = text,
     style = MaterialTheme.typography.labelSmall,
     fontWeight = FontWeight.SemiBold,
     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+    textAlign = textAlign,
+    modifier = modifier
 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -227,6 +228,7 @@ private fun SpectrumPlotContainer(
         ) {
             Box(
                 modifier = Modifier.weight(1f)
+                    .clipToBounds()
             ) {
                 content()
             }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
@@ -35,7 +35,7 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
 
         const val DBA_MIN = 0.0
         const val DBA_MAX = 100.0
-        const val DBA_TICKS_COUNT = 5
+        const val DBA_TICKS_COUNT = 4
     }
 
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.zip
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.services.audio.LiveAudioService
@@ -16,9 +17,15 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
     // - Associated types
 
     data class AxisSettings(
-        val minimumX: Double,
-        val maximumX: Double,
         val nominalFrequencies: List<Int>,
+        val minimumX: Double = DBA_MIN,
+        val maximumX: Double = DBA_MAX,
+        val xTicksCount: Int = DBA_TICKS_COUNT,
+    )
+
+    data class SplData(
+        val raw: Double,
+        val weighted: Double,
     )
 
 
@@ -28,6 +35,7 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
 
         const val DBA_MIN = 0.0
         const val DBA_MAX = 100.0
+        const val DBA_TICKS_COUNT = 5
     }
 
 
@@ -42,34 +50,24 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
         Pair(rampIndex.toFloat(), color)
     }
 
-    val rawSplFlow: StateFlow<Map<Int, Double>> = liveAudioService
+    val splDataFlow: StateFlow<Map<Int, SplData>> = liveAudioService
         .getLeqRecordsFlow()
-        .map { it.leqsPerThirdOctave }
-        .stateInWhileSubscribed(
+        .zip(liveAudioService.getWeightedLeqPerFrequencyBandFlow()) { raw, weighted ->
+            raw.leqsPerThirdOctave.mapValues { entry ->
+                SplData(entry.value, weighted[entry.key] ?: 0.0)
+            }
+        }.stateInWhileSubscribed(
             scope = viewModelScope,
             initialValue = emptyMap(),
-        )
-
-    val weightedSplFlow: StateFlow<Map<Int, Double>> = liveAudioService
-        .getWeightedLeqPerFrequencyBandFlow()
-        .stateInWhileSubscribed(
-            scope = viewModelScope,
-            initialValue = emptyMap()
         )
 
     val axisSettingsFlow: StateFlow<AxisSettings> = liveAudioService
         .getLeqRecordsFlow()
         .map { it.leqsPerThirdOctave.keys.toList() }
         .distinctUntilChanged()
-        .map {
-            AxisSettings(
-                minimumX = DBA_MIN,
-                maximumX = DBA_MAX,
-                nominalFrequencies = it
-            )
-        }
+        .map { AxisSettings(nominalFrequencies = it) }
         .stateInWhileSubscribed(
             scope = viewModelScope,
-            initialValue = AxisSettings(0.0, 0.0, emptyList())
+            initialValue = AxisSettings(nominalFrequencies = emptyList())
         )
 }


### PR DESCRIPTION
# Description

Rewrote `SpectrumPlotView` using composable instead of manual Canvas drawing. This allows to fix some caveats of the old method:

- Bars and boxes can smoothly animate between two states (instead of being limited to 8 fps (125ms)). See GIFs below for comparison
- Placement of axis labels is calculated automatically during first composition (less manual logic to handle on our side)

| Before | After |
| ------ | ----- |
| ![ScreenRecording2025-07-10at11 08 36-ezgif com-optimize](https://github.com/user-attachments/assets/703f37b0-1dbc-4925-a3c3-9bf000bd519e) | ![ScreenRecording2025-07-10at11 46 13-ezgif com-optimize](https://github.com/user-attachments/assets/209e7a89-7c05-4aa5-88a3-cf67d82f0e20) |

It was maybe not top priority but I wanted to try it out now that I have a bit more Compose knowledge 😁 

## Changes

- Axes are placed using `Row` and `Column`
- Plot area is painted once using the noise color ramp gradient
- Bars are drawn negatively (right aligned inverse value) on top of the background. Width is animated between two values.
- Axis grids are drawn on top of the bars to add vertical and horizontal dividers
- Weighted SPL boxes are drawn using `Modifier.align(BiasAlignment.Horizontal(bias))` for relative positionning

## Linked issues

- #128 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
