### PR TITLE
Testing improved contrast of color palette

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0'
+          xcode-version: latest-stable
 
       - name: set up JDK
         uses: actions/setup-java@v3

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/LAeqMetricsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/LAeqMetricsView.kt
@@ -72,7 +72,10 @@ fun LAeqMetricsView(
                         textAlign = TextAlign.Start,
                         lineHeight = 24.sp,
                         color = metric.value?.let {
-                            NoiseLevelColorRamp.getColorForSPLValue(it)
+                            NoiseLevelColorRamp.getColorForSPLValue(
+                                value = it,
+                                palette = NoiseLevelColorRamp.paletteDarker,
+                            )
                         } ?: MaterialTheme.colorScheme.onSurface,
                     ),
                     maxLines = 1,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterView.kt
@@ -45,7 +45,12 @@ fun SoundLevelMeterView(
     val playPauseButtonViewModel by viewModel.playPauseButtonViewModelFlow
         .collectAsStateWithLifecycle()
 
-    val currentSplColor by animateColorAsState(NoiseLevelColorRamp.getColorForSPLValue(currentSpl))
+    val currentSplColor by animateColorAsState(
+        NoiseLevelColorRamp.getColorForSPLValue(
+            value = currentSpl,
+            palette = NoiseLevelColorRamp.paletteDarker,
+        )
+    )
 
 
     // - Layout

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/VuMeter.kt
@@ -41,7 +41,12 @@ fun VuMeter(
     val value: Double by valueFlow.collectAsStateWithLifecycle()
     val valueRatio = (value - minimum) / (maximum - minimum)
 
-    val color by animateColorAsState(NoiseLevelColorRamp.getColorForSPLValue(value))
+    val color by animateColorAsState(
+        NoiseLevelColorRamp.getColorForSPLValue(
+            value = value,
+            palette = NoiseLevelColorRamp.paletteDarker,
+        )
+    )
     val shape = RoundedCornerShape(
         topStartPercent = 0,
         bottomStartPercent = 0,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/MeasurementDetailsChartsHeader.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/MeasurementDetailsChartsHeader.kt
@@ -35,7 +35,14 @@ fun MeasurementDetailsChartsHeader(
 ) {
     // - Properties
 
-    val averageLevelColor: Color = NoiseLevelColorRamp.getColorForSPLValue(averageLevel)
+    val averageLevelColorTint: Color = NoiseLevelColorRamp.getColorForSPLValue(
+        value = averageLevel,
+        palette = NoiseLevelColorRamp.paletteDarker,
+    )
+    val averageLevelColorBackground: Color = NoiseLevelColorRamp.getColorForSPLValue(
+        value = averageLevel,
+        palette = NoiseLevelColorRamp.paletteLighter,
+    )
 
 
     // - Layout
@@ -78,13 +85,13 @@ fun MeasurementDetailsChartsHeader(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.clip(RoundedCornerShape(size = 16.dp))
-                .background(averageLevelColor.copy(alpha = 0.15f))
+                .background(averageLevelColorBackground)
                 .padding(20.dp)
         ) {
             Text(
                 text = averageLevel.roundTo(1).toString(),
                 style = MaterialTheme.typography.headlineLarge,
-                color = averageLevelColor,
+                color = averageLevelColorTint,
                 fontWeight = FontWeight.Black,
                 fontSize = 36.sp,
                 lineHeight = 40.sp,
@@ -92,7 +99,7 @@ fun MeasurementDetailsChartsHeader(
             Text(
                 text = stringResource(Res.string.measurement_details_average_level),
                 style = MaterialTheme.typography.labelSmall,
-                color = averageLevelColor,
+                color = averageLevelColorTint,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotView.kt
@@ -73,7 +73,7 @@ fun SpectrumPlotView(
                 dbMin = SpectrumPlotViewModel.DBA_MIN,
                 dbMax = SpectrumPlotViewModel.DBA_MAX,
             ).map { (rampIndex, color) ->
-                Pair(rampIndex.toFloat(), color)
+                Pair(rampIndex.toFloat(), color.copy(alpha = 1f))
             }.toTypedArray()
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
@@ -4,13 +4,15 @@ import androidx.compose.ui.graphics.Color
 import org.noiseplanet.noisecapture.util.VuMeterOptions
 
 /**
- * SPL color representation based on
- * [this palette](https://noisemodelling.readthedocs.io/en/latest/Noise_Map_Color_Scheme.html#coloring-noise)
+ * SPL color representation based on [this palette](https://www.coloringnoise.com/).
  */
 object NoiseLevelColorRamp {
 
     // - Properties
 
+    /**
+     * Base color palette with true colors picked from [Coloring Noise](https://www.coloringnoise.com/)
+     */
     val palette: Map<Double, Color> = mapOf(
         0.0 to Color(0xFF82A6AD),
         35.0 to Color(0xFFA0BABF),
@@ -25,12 +27,47 @@ object NoiseLevelColorRamp {
         80.0 to Color(0xFF430A4A),
     )
 
+    /**
+     * A darker version of the color palette to provide better contrast against light backgrounds
+     */
+    val paletteDarker: Map<Double, Color> = mapOf(
+        0.0 to Color(0xFF576F73),
+        35.0 to Color(0xFF6B7C7F),
+        40.0 to Color(0xFF7B8F8B),
+        45.0 to Color(0xFF899888),
+        50.0 to Color(0xFF97A17F),
+        55.0 to Color(0xFFA28457),
+        60.0 to Color(0xFFC16940),
+        65.0 to Color(0xFFCD463E),
+        70.0 to Color(0xFFA11A4D),
+        75.0 to Color(0xFF75085C),
+        80.0 to Color(0xFF430A4A),
+    )
+
+    /**
+     * A lighter version of the color palette to use as background tint.
+     */
+    val paletteLighter: Map<Double, Color> = mapOf(
+        0.0 to Color(0xFFE6EDEF),
+        35.0 to Color(0xFFECF1F2),
+        40.0 to Color(0xFFF1F7F6),
+        45.0 to Color(0xFFF5FAF5),
+        50.0 to Color(0xFFF9FCF2),
+        55.0 to Color(0xFFFDF4E6),
+        60.0 to Color(0xFFFAE5DB),
+        65.0 to Color(0xFFF5DAD8),
+        70.0 to Color(0xFFECD1DB),
+        75.0 to Color(0xFFE3CEDE),
+        80.0 to Color(0xFFD9CEDB),
+    )
+
 
     // - Public functions
 
     /**
      * Get color palette mapping levels to a 0-1 scale based on given min and max values.
      *
+     * @param palette Color palette to sample from
      * @param dbMin Target ramp lower bound in decibels
      * @param dbMax Target ramp upper bound in decibels
      * @param reversed If true, output ramp will be 0.0 for highest level, 1.0 for lowest level.
@@ -39,6 +76,7 @@ object NoiseLevelColorRamp {
         dbMin: Double = VuMeterOptions.DB_MIN,
         dbMax: Double = VuMeterOptions.DB_MAX,
         reversed: Boolean = false,
+        palette: Map<Double, Color> = NoiseLevelColorRamp.palette,
     ): Map<Double, Color> {
         return palette.mapKeys { (spl, _) ->
             // Map spl index to a value between 0 and 1 based on min/max dB values
@@ -55,11 +93,15 @@ object NoiseLevelColorRamp {
     /**
      * Get the color corresponding to the given SPL value
      *
+     * @param palette Color palette to sample from
      * @param value SPL value
      *
      * @return Corresponding color from palette
      */
-    fun getColorForSPLValue(value: Double): Color {
+    fun getColorForSPLValue(
+        value: Double,
+        palette: Map<Double, Color> = NoiseLevelColorRamp.palette,
+    ): Color {
         return palette.filter { it.key <= value }
             .minByOrNull { value - it.key }
             ?.value


### PR DESCRIPTION
# Description

Trying to improve contrast on lighter backgrounds

## Changes

Adds a darker variant of the noise level color palette to ensure better contrast over light backgrounds (at least 3:1 ratio which is minimum for large texts according to [WCAG accessibility norm](https://accessibleweb.com/color-contrast-checker/).

After discussing with @gpetit, this is a first test that keeps the original palette for plots (spectrum and spl over time) and later for map representations, but use the darker versions for displaying values (Sound level meter and colored values in measurement details).

## Linked issues

- #144

## Remaining TODOs

I think there are still some improvements that could be made to ensure a more consistent look and avoid switching between the two palettes as much as possible to avoid confusion from a user perspective. Maybe we could figure out solutions to avoid displaying colored text but instead use other ways to include the color palette. 

I'll work on some future designs to try out other things, but this is at least a working version to demonstrate how this "new" palette would look like in situ.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
