### PR TITLE
Feature/local storage versionning

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LeqSequenceFragment.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LeqSequenceFragment.kt
@@ -5,6 +5,11 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
+ * Current model version, used for potential migrations.
+ */
+val LeqSequenceFragment.Companion.VERSION: Int get() = 1
+
+/**
  * For compression reasons when storing values in JSON format, we want to group values
  * into a representation where each property is an array of values to spare writing the
  * keys everytime.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LocationSequenceFragment.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LocationSequenceFragment.kt
@@ -5,6 +5,11 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
+ * Current model version, used for potential migrations.
+ */
+val LocationSequenceFragment.Companion.VERSION: Int get() = 1
+
+/**
  * For compression reasons when storing values in JSON format, we want to group values
  * into a representation where each property is an array of values to spare writing the
  * keys everytime.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/Measurement.kt
@@ -3,6 +3,11 @@ package org.noiseplanet.noisecapture.model.dao
 import kotlinx.serialization.Serializable
 
 /**
+ * Current model version, used for potential migrations.
+ */
+val Measurement.Companion.VERSION: Int get() = 1
+
+/**
  * Represents a measurement consisting of acoustic indicators recorded at different locations.
  *
  * @param uuid Unique measurement identifier.

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/ServicesModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/ServicesModule.kt
@@ -3,7 +3,6 @@ package org.noiseplanet.noisecapture.services
 import org.koin.dsl.module
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationSequenceFragment
-import org.noiseplanet.noisecapture.model.dao.Measurement
 import org.noiseplanet.noisecapture.services.audio.DefaultLiveAudioService
 import org.noiseplanet.noisecapture.services.audio.LiveAudioService
 import org.noiseplanet.noisecapture.services.location.DefaultUserLocationService
@@ -16,6 +15,7 @@ import org.noiseplanet.noisecapture.services.permission.DefaultPermissionService
 import org.noiseplanet.noisecapture.services.permission.PermissionService
 import org.noiseplanet.noisecapture.services.settings.DefaultUserSettingsService
 import org.noiseplanet.noisecapture.services.settings.UserSettingsService
+import org.noiseplanet.noisecapture.services.storage.MeasurementStorageService
 import org.noiseplanet.noisecapture.services.storage.kstore.KStoreStorageService
 import org.noiseplanet.noisecapture.services.storage.singleStorageService
 
@@ -51,10 +51,7 @@ val servicesModule = module {
     // - Storage
 
     singleStorageService {
-        KStoreStorageService(
-            prefix = "measurement",
-            type = Measurement::class,
-        )
+        MeasurementStorageService()
     }
 
     singleStorageService {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/MeasurementStorageService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/MeasurementStorageService.kt
@@ -1,0 +1,77 @@
+package org.noiseplanet.noisecapture.services.storage
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
+import org.noiseplanet.noisecapture.model.dao.LocationSequenceFragment
+import org.noiseplanet.noisecapture.model.dao.Measurement
+import org.noiseplanet.noisecapture.services.storage.kstore.KStoreStorageService
+import org.noiseplanet.noisecapture.util.injectLogger
+
+
+class MeasurementStorageService : KStoreStorageService<Measurement>(
+    prefix = "measurement",
+    type = Measurement::class,
+) {
+    // - Properties
+
+    private val logger: Logger by injectLogger()
+
+    private val locationSequenceStorageService: StorageService<LocationSequenceFragment> by injectStorageService()
+    private val leqSequenceStorageService: StorageService<LeqSequenceFragment> by injectStorageService()
+
+
+    // - Public functions
+
+    /**
+     * When migrating a measurement, also handle potential sub effects of underlying sequence fragments.
+     */
+    override suspend fun migrate(
+        uuid: String,
+        currentVersion: Int,
+        storedVersion: Int?,
+        storedData: JsonElement?,
+    ): Measurement? {
+        logger.warning("Could not deserialize measurement with id: $uuid")
+        logger.warning("Deleting measurement...")
+
+        storedData?.jsonObject?.get("leqsSequenceIds")?.jsonArray?.forEach { leqSequenceId ->
+            logger.warning("Deleting leq sequence fragment $leqSequenceId...")
+            leqSequenceStorageService.delete(leqSequenceId.jsonPrimitive.content)
+        }
+        storedData?.jsonObject?.get("locationSequenceIds")?.jsonArray?.forEach { locationSequenceId ->
+            logger.warning("Deleting location sequence fragment $locationSequenceId...")
+            leqSequenceStorageService.delete(locationSequenceId.jsonPrimitive.content)
+        }
+
+        logger.warning("Deleting measurement object...")
+        super.delete(uuid)
+        logger.warning("Done cleaning up measurement with id: $uuid")
+
+        return null
+    }
+
+    /**
+     * Override delete method to also delete associated sequence fragments.
+     *
+     * TODO: Perhaps this should move to MeasurementService...
+     */
+    override suspend fun delete(uuid: String) {
+        val measurement = get(uuid) ?: return
+
+        // Delete all attached LEq sequence fragments
+        measurement.leqsSequenceIds.forEach {
+            leqSequenceStorageService.delete(it)
+        }
+        // Delete all attached location sequence fragments
+        measurement.locationSequenceIds.forEach {
+            locationSequenceStorageService.delete(it)
+        }
+
+        // Lastly, delete the measurement itself
+        super.delete(uuid)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/StorageService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/StorageService.kt
@@ -2,6 +2,7 @@ package org.noiseplanet.noisecapture.services.storage
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 
 /**
@@ -39,6 +40,26 @@ interface StorageService<T : @Serializable Any> {
      * @return Entity instance or null if not found in storage
      */
     suspend fun get(uuid: String): T?
+
+    /**
+     * Migrates the given entity from the given stored version to the current version. Triggered when
+     * trying to deserialize a model unsuccessfully.
+     *
+     * By default, this function just removes the stored version from disk and returns null.
+     * Override this method in model specific [StorageService] implementations to provide a proper
+     * custom migration behaviour.
+     *
+     * @param uuid Unique entity identifier
+     * @param currentVersion Version of the stored entity.
+     * @param storedVersion Current entity version.
+     * @param storedData Raw json data that couldn't be parsed automatically to the current entity version.
+     */
+    suspend fun migrate(
+        uuid: String,
+        currentVersion: Int,
+        storedVersion: Int?,
+        storedData: JsonElement?,
+    ): T?
 
     /**
      * Gets the size of an entity in bytes from its unique identifier

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.kt
@@ -19,7 +19,7 @@ internal typealias Migration<T> = suspend (
 /**
  * A default migration that does nothing and returns null.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionNaming", "FunctionName")
 fun <T> DefaultMigration(): Migration<T> = { _, _ -> null }
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.kt
@@ -2,6 +2,25 @@ package org.noiseplanet.noisecapture.services.storage.kstore
 
 import io.github.xxfast.kstore.KStore
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Defines the signature of the migration method that will be called when unable to deserialize
+ * an object due to version mismatch.
+ *
+ * @param storedVersion Stored entity version.
+ * @param storedData Raw json data that couldn't be parsed automatically to the current entity version.
+ */
+internal typealias Migration<T> = suspend (
+    storedVersion: Int?,
+    storedData: JsonElement?,
+) -> T?
+
+/**
+ * A default migration that does nothing and returns null.
+ */
+@Suppress("FunctionName")
+fun <T> DefaultMigration(): Migration<T> = { _, _ -> null }
 
 /**
  * Abstracts providing the store object itself to be adapted for each separate platform.
@@ -25,6 +44,8 @@ internal expect class KStoreProvider() {
      */
     inline fun <reified T : @Serializable Any> storeOf(
         fileName: String,
+        version: Int = 0,
+        noinline migration: Migration<T> = DefaultMigration(),
         enableCache: Boolean = true,
     ): KStore<T>
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
@@ -30,6 +30,7 @@ import kotlin.reflect.KClass
  *               (i.e. for measurements, all records will be stored under "{appDir}/measurements/{id}.json"
  * @param RecordType Type of entity to be stored
  */
+@Suppress("TooManyFunctions")
 open class KStoreStorageService<RecordType : @Serializable Any>(
     private val prefix: String,
     private val type: KClass<RecordType>,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
@@ -8,11 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import org.koin.core.component.KoinComponent
+import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.model.dao.LeqSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.LocationSequenceFragment
 import org.noiseplanet.noisecapture.model.dao.Measurement
+import org.noiseplanet.noisecapture.model.dao.VERSION
 import org.noiseplanet.noisecapture.services.storage.StorageService
+import org.noiseplanet.noisecapture.util.injectLogger
 import kotlin.reflect.KClass
 
 
@@ -26,12 +30,14 @@ import kotlin.reflect.KClass
  *               (i.e. for measurements, all records will be stored under "{appDir}/measurements/{id}.json"
  * @param RecordType Type of entity to be stored
  */
-class KStoreStorageService<RecordType : @Serializable Any>(
+open class KStoreStorageService<RecordType : @Serializable Any>(
     private val prefix: String,
     private val type: KClass<RecordType>,
 ) : StorageService<RecordType>, KoinComponent {
 
     // - Properties
+
+    private val logger: Logger by injectLogger()
 
     private val storeProvider = KStoreProvider()
     private val indexStore: KStore<List<String>> = storeProvider.storeOf(
@@ -58,6 +64,20 @@ class KStoreStorageService<RecordType : @Serializable Any>(
     override suspend fun get(uuid: String): RecordType? {
         val store = storeCache[uuid] ?: getStoreForRecord(uuid)
         return store.get()
+    }
+
+    override suspend fun migrate(
+        uuid: String,
+        currentVersion: Int,
+        storedVersion: Int?,
+        storedData: JsonElement?,
+    ): RecordType? {
+        logger.warning("Couldn't deserialize versioned entity with id: $uuid")
+        logger.warning("Current model version: $currentVersion / Stored version: $storedVersion")
+        logger.warning("No custom migration provided, deleting.")
+
+        delete(uuid)
+        return null
     }
 
     override suspend fun getSize(uuid: String): Long? {
@@ -119,18 +139,51 @@ class KStoreStorageService<RecordType : @Serializable Any>(
      */
     @Suppress("UNCHECKED_CAST")
     private fun getStoreForRecord(uuid: String): KStore<RecordType> {
-        val key = getFileNameForRecord(uuid)
-
         // Check at runtime for record type
         return when (type) {
-            Measurement::class -> storeProvider.storeOf<Measurement>(key)
-            LeqSequenceFragment::class -> storeProvider.storeOf<LeqSequenceFragment>(key)
-            LocationSequenceFragment::class -> storeProvider.storeOf<LocationSequenceFragment>(key)
+            Measurement::class -> storeForTypedRecord<Measurement>(
+                uuid,
+                modelVersion = Measurement.VERSION
+            )
+
+            LeqSequenceFragment::class -> storeForTypedRecord<LeqSequenceFragment>(
+                uuid,
+                modelVersion = LeqSequenceFragment.VERSION
+            )
+
+            LocationSequenceFragment::class -> storeForTypedRecord<LocationSequenceFragment>(
+                uuid,
+                modelVersion = LocationSequenceFragment.VERSION
+            )
 
             // Add other types that can be stored here.
 
             else -> throw UnsupportedOperationException("Trying to access unsupported storage type")
         } as KStore<RecordType>
+    }
+
+    /**
+     * Wrapper for `storeProvider.storeOf` call using a reified type to avoid duplicating migration
+     * encapsulation for every model type.
+     */
+    private inline fun <reified T : Any> storeForTypedRecord(
+        uuid: String,
+        modelVersion: Int,
+    ): KStore<T> {
+        val fileName = getFileNameForRecord(uuid)
+
+        return storeProvider.storeOf(
+            fileName = fileName,
+            version = modelVersion,
+            migration = { version, data ->
+                migrate(
+                    uuid = uuid,
+                    currentVersion = modelVersion,
+                    storedVersion = version,
+                    storedData = data
+                ) as T?
+            }
+        )
     }
 
     private fun getFileNameForRecord(uuid: String): String {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreOpfsCodec.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreOpfsCodec.kt
@@ -5,7 +5,10 @@ import io.github.xxfast.kstore.DefaultJson
 import kotlinx.coroutines.await
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.serializer
 import org.noiseplanet.noisecapture.interop.storage.FileSystemWritableFileStream
 import org.noiseplanet.noisecapture.log.Logger
@@ -29,12 +32,61 @@ class KStoreOpfsCodec<T : @Serializable Any>(
     private val filePath: String,
     private val json: Json,
     private val serializer: KSerializer<T>,
+    private val version: Int,
+    private val migration: Migration<T>,
     private val logger: Logger,
 ) : Codec<T> {
+
+    // - Properties
+
+    val versionFilePath: String = "$filePath.version"
+
 
     // - Codec
 
     override suspend fun decode(): T? {
+        val jsonString = readFileContent(filePath) ?: return null
+
+        // Try to decode JSON from string
+        return try {
+            json.decodeFromString(serializer, jsonString)
+        } catch (e: SerializationException) {
+            logger.warning(
+                "Failed deserialization of object in file $filePath. " +
+                    "This is probably due to a change in the model and should trigger a migration.",
+                throwable = e,
+            )
+
+            val previousVersion: Int? = readFileContent(versionFilePath)?.let {
+                json.decodeFromString(Int.serializer(), it)
+            }
+            val rawJsonData: JsonElement = json.decodeFromString(jsonString)
+            migration(previousVersion, rawJsonData)
+        }
+    }
+
+    override suspend fun encode(value: T?) {
+        value?.let { unwrappedValue ->
+            // Serialise data to JSON
+            val data = json.encodeToString(serializer, unwrappedValue)
+            // Write JSON data to file
+            writeToFile(filePath, data)
+            // Serialize version data
+            val versionData = json.encodeToString(Int.serializer(), version)
+            // Write version data to file
+            writeToFile(versionFilePath, versionData)
+        } ?: run {
+            // Get file and directory handles if they exist
+            val (fileHandle, directoryHandle) = OPFSHelper.getFileHandle(filePath) ?: return
+            // If value is null, delete the file
+            directoryHandle.removeEntry(fileHandle.name).await()
+        }
+    }
+
+
+    // - Private functions
+
+    private suspend fun readFileContent(filePath: String): String? {
         // Get file and directory handles
         val (fileHandle, _) = OPFSHelper.getFileHandle(filePath) ?: return null
         val file = fileHandle.getFile().await<File>()
@@ -43,37 +95,27 @@ class KStoreOpfsCodec<T : @Serializable Any>(
         val reader = FileReader()
         // Read contents from file. Since FileReader relies on a callback to get the contents
         // after reading, we wrap this in a suspendCoroutine to synchronise the result
-        val fileContents = suspendCoroutine { continuation ->
+        return suspendCoroutine { continuation ->
             reader.readAsText(file)
             reader.addEventListener("load") {
                 // Continue execution when contents are available.
-                continuation.resume(reader.result)
+                continuation.resume(reader.result?.toString())
             }
-        }
-        // Decode JSON from string
-        return json.decodeFromString(serializer, fileContents.toString())
+        }.toString()
     }
 
-    override suspend fun encode(value: T?) {
-        // Get file and directory handles, create them if not found
-        val (fileHandle, directoryHandle) = OPFSHelper.getFileHandle(
+    private suspend fun writeToFile(filePath: String, data: String) {
+        // Get file handle, create it if not found
+        val (fileHandle, _) = OPFSHelper.getFileHandle(
             filePath,
             createIfNotFound = true
         ) ?: return
-
-        value?.let { unwrappedValue ->
-            // Serialise data to JSON
-            val data = json.encodeToString(serializer, unwrappedValue)
-            // Get writer handle
-            val stream: FileSystemWritableFileStream = fileHandle.createWritable().await()
-            // Write data to file
-            stream.write(data.toJsString()).await<Unit>()
-            // Close writer handle
-            stream.close().await<Unit>()
-        } ?: run {
-            // If value is null, delete the file
-            directoryHandle.removeEntry(fileHandle.name).await<Unit>()
-        }
+        // Get writer handle
+        val stream: FileSystemWritableFileStream = fileHandle.createWritable().await()
+        // Write data to file
+        stream.write(data.toJsString()).await<Unit>()
+        // Close writer handle
+        stream.close().await<Unit>()
     }
 }
 
@@ -84,11 +126,15 @@ class KStoreOpfsCodec<T : @Serializable Any>(
 @Suppress("FunctionNaming")
 inline fun <reified T : @Serializable Any> KStoreOpfsCodec(
     filePath: String,
+    version: Int,
     logger: Logger,
+    noinline migration: Migration<T> = DefaultMigration(),
     json: Json = DefaultJson,
 ) = KStoreOpfsCodec<T>(
     filePath = filePath,
     json = json,
+    version = version,
+    migration = migration,
     serializer = json.serializersModule.serializer(),
     logger = logger,
 )

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.wasmjs.kt
@@ -34,6 +34,8 @@ internal actual class KStoreProvider : KoinComponent {
      */
     actual inline fun <reified T : @Serializable Any> storeOf(
         fileName: String,
+        version: Int,
+        noinline migration: Migration<T>,
         enableCache: Boolean,
     ): KStore<T> {
         // For WasmJS, KStore doesn't support file storage out of the box so we use a custom codec
@@ -42,6 +44,8 @@ internal actual class KStoreProvider : KoinComponent {
             codec = KStoreOpfsCodec(
                 filePath = fileName,
                 logger = logger,
+                version = version,
+                migration = migration,
             ),
             enableCache = enableCache,
         )


### PR DESCRIPTION
# Description

Adds versioning mechanism to models stored in local storage using KStore.

## Changes

I had to trick a little because the default `VersionedCodec` implementation is only available for iOS and Android. What I ended up coming up with is the following:

- Added a `VERSION` static property to the stored models that holds the current version of the model.
- For each stored model, stores an additional `{filename}.version` file that only contains the version number.
- When failing to deserialise an object, calls the associated `Migration<T>` callback with the stored version number (or `0` if no version file was found) and the raw `JsonElement` that can be manually parsed.
- Added a `migrate` method to `KStoreProvider` that takes care of migrating an object from the stored version to the current version.
- The default behaviour of this method is simply to delete the stored object. Meaning if we add a new property to one of those models, the app will simply cleanup old models that can't be parsed and move on. When we'll move to a more stable/production phase, we can start adding proper migrations.
- To implement custom migration behaviour, we can just override the `migrate` method in subclasses of `KStoreStorageService`, see `MeasurementStorageService` for an example.

Also fixed a bug where when deleting a measurement, associated leq sequences and location sequences were not deleted with it.

## Linked issues

- #97 

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
